### PR TITLE
Sinkronisasi File Foto Penduduk OpenSID melalui API OpenDK

### DIFF
--- a/app/Http/Controllers/Api/PendudukController.php
+++ b/app/Http/Controllers/Api/PendudukController.php
@@ -6,6 +6,30 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\PendudukRequest;
 use App\Jobs\PendudukQueueJob;
 
+use Illuminate\Http\Request;
+use App\Imports\ImporPenduduk;
+use App\Models\Penduduk;
+use Doctrine\DBAL\Query\QueryException;
+use Exception;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Yajra\DataTables\DataTables;
+use ZipArchive;
+
+use function back;
+use function compact;
+use function config;
+use function convert_born_date_to_age;
+use function redirect;
+use function request;
+use function route;
+use function strtolower;
+use function substr;
+use function ucwords;
+use function view;
+
 class PendudukController extends Controller
 {
     /**
@@ -20,7 +44,7 @@ class PendudukController extends Controller
 
     /**
      * Insert penduduk ke OpenDK.
-     * 
+     *
      * @param PendudukRequest $request
      * @return \Illuminate\Http\JsonResponse
      */
@@ -32,5 +56,48 @@ class PendudukController extends Controller
         return response()->json([
             'message' => 'Proses sync data penduduk OpenSID sedang berjalan',
         ]);
+    }
+
+    /**
+     * Insert foto penduduk dari OpenSID ke OpenDK
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function storefoto(Request $request)
+    {
+      $this->validate($request, [
+        'file' => 'file|mimes:zip|max:5120',
+      ]);
+
+      try {
+        // Upload file zip temporary.
+        $file = $request->file('file');
+        $file->storeAs('temp', $name = $file->getClientOriginalName());
+
+        // Temporary path file
+        $path = storage_path("app/temp/{$name}");
+        $extract = storage_path('app/public/penduduk/foto/');
+
+        // Ekstrak file
+        $zip = new ZipArchive;
+        $zip->open($path);
+        $zip->extractTo($extract);
+        $zip->close();
+
+        // Proses impor excell
+        (new ImporPenduduk($request))
+        ->import($extract . $excellName = Str::replaceLast('zip', 'xlsx', $name));
+      } catch (Exception $e) {
+        return back()->with('error', 'Import data gagal. ' . $e->getMessage());
+      }
+
+      // Hapus folder temp ketika sudah selesai
+      Storage::deleteDirectory('temp');
+      // Hapus file excell temp ketika sudah selesai
+      Storage::disk('public')->delete('penduduk/foto/' . $excellName);
+
+      return response()->json([
+        "message" => "Data Foto Telah Berhasil di Sinkronkan",
+      ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 // Route::middleware('auth:api')->get('/user', function (Request $request) {
 //     return $request->user();
 // });
-  
+
 Route::group(['prefix' => 'v1'], function() {
     /**
      * Authentication api
@@ -33,6 +33,7 @@ Route::group(['prefix' => 'v1'], function() {
      */
     Route::group(['prefix' => 'penduduk'], function () {
         Route::post('/', 'Api\PendudukController@store');
+        Route::post('foto', 'Api\PendudukController@storefoto');
         Route::post('test', 'Api\PendudukController@test');
     });
 });


### PR DESCRIPTION
Setelah proses sinkronisasi data penduduk selesai maka file foto juga harus disinkronkan guna menambah atau merubah file foto di OpenDK melalui API :

Menu Pengaturan -> Database -> Sinkronisasi DB OpenDK -> Tombol "Sinkronkan Data Foto OpenDK"
![opendk_foto1](https://user-images.githubusercontent.com/10391199/102694439-9ede0000-4253-11eb-9426-783fe3432b1d.PNG)

Setelah proses selesai maka file foto di OpenDK sudah diperbaharui dan bisa ditampilkan :
![opendk_foto2](https://user-images.githubusercontent.com/10391199/102694451-ab625880-4253-11eb-8d22-c6711cd633b2.PNG)

File foto penduduk di simpan di {{ asset('storage/penduduk/foto') }}
