### PR TITLE
Perbaiki proses simpan ketika tambah/ubah foto

### DIFF
--- a/app/Http/Controllers/Data/PendudukController.php
+++ b/app/Http/Controllers/Data/PendudukController.php
@@ -46,7 +46,7 @@ class PendudukController extends Controller
 
     /**
      * Return datatable Data Penduduk.
-     * 
+     *
      * @param Request $request
      * @return DataTables
      */
@@ -61,6 +61,7 @@ class PendudukController extends Controller
             ->leftJoin('ref_pekerjaan', 'das_penduduk.pekerjaan_id', '=', 'ref_pekerjaan.id')
             ->select([
                 'das_penduduk.id',
+                'das_penduduk.foto',
                 'das_penduduk.nik',
                 'das_penduduk.nama',
                 'das_penduduk.no_kk',
@@ -144,7 +145,7 @@ class PendudukController extends Controller
                 $file     = $request->file('foto');
                 $fileName = $file->getClientOriginalName();
                 $request->file('foto')->move("storage/penduduk/foto/", $fileName);
-                $penduduk->foto = 'storage/penduduk/foto/' . $fileName;
+                $penduduk->foto = $fileName;
             }
 
             $penduduk->save();
@@ -206,7 +207,7 @@ class PendudukController extends Controller
                 $file     = $request->file('foto');
                 $fileName = $file->getClientOriginalName();
                 $request->file('foto')->move("storage/penduduk/foto/", $fileName);
-                $penduduk->foto = 'storage/penduduk/foto/' . $fileName;
+                $penduduk->foto = $fileName;
             }
 
             $penduduk->update();
@@ -263,7 +264,7 @@ class PendudukController extends Controller
             // Upload file zip temporary.
             $file = $request->file('file');
             $file->storeAs('temp', $name = $file->getClientOriginalName());
-            
+
             // Temporary path file
             $path = storage_path("app/temp/{$name}");
             $extract = storage_path('app/public/penduduk/foto/');


### PR DESCRIPTION
Foto penduduk tidak bisa disimpan ketika tambah/ubah foto penduduk karena di depan nama file ditambahkan prefix 'storage/penduduk/foto/' .