### PR TITLE
fixed uri /dashboard/kependudukan issue when das_penduduk tables empty.

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardKependudukanController.php
+++ b/app/Http/Controllers/Dashboard/DashboardKependudukanController.php
@@ -46,6 +46,9 @@ class DashboardKependudukanController extends Controller
     /* Menghasilkan array berisi semua tahun di mana penduduk tercatat sampai tahun sekarang */
     protected function years_list()
     {
+        if (DB::table('das_penduduk')->first() == null) {
+            return [];
+        }
         $tahun_tertua = DB::table('das_penduduk')
             ->select(DB::raw('YEAR(created_at) as tahun'))
             ->distinct()


### PR DESCRIPTION
kalo table das_penduduk kosong maka uri /dashboard/kependudukan

akan memunculkan error
```php
ErrorException (E_WARNING)
Attempt to read property "tahun" on null
```
karena script di bawah hasilnya kosong/null

```php
$tahun_tertua = DB::table('das_penduduk')->select(DB::raw('YEAR(created_at) as tahun'))->distinct()->orderBy('tahun', 'desc')->limit(1)->get()->first()
```
di bawah ini print screen-nya.

![image](https://user-images.githubusercontent.com/4870292/103588853-b936ff80-4f1c-11eb-8982-646901f5299e.png)

saya buat PR 1 lagi, solusi untuk masalah yang sama tapi dengan cara lain. 

mohon di review dan silahkan di pilih salah satu

terima kasih