### PR TITLE
option 2: fixed uri /dashboard/kependudukan issue when das_penduduk tables empty.

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardKependudukanController.php
+++ b/app/Http/Controllers/Dashboard/DashboardKependudukanController.php
@@ -51,7 +51,12 @@ class DashboardKependudukanController extends Controller
             ->distinct()
             ->orderBy('tahun', 'desc')
             ->limit(1)
-            ->get()->first()->tahun;
+            ->get()->first();
+
+        if ($tahun_tertua == null) {
+            return [];
+        }
+        $tahun_tertua = $tahun_tertua->tahun;
         $tahun_tertua = $tahun_tertua ?: date("Y");
         $years = [];
         for ($y = $tahun_tertua; $y <= date("Y"); $y++) {


### PR DESCRIPTION
kalo table das_penduduk kosong maka uri /dashboard/kependudukan

akan memunculkan error
```php
ErrorException (E_WARNING)
Attempt to read property "tahun" on null
```
karena script di bawah hasilnya kosong/null

```php
$tahun_tertua = DB::table('das_penduduk')->select(DB::raw('YEAR(created_at) as tahun'))->distinct()->orderBy('tahun', 'desc')->limit(1)->get()->first()
```
di bawah ini print screen-nya.

![image](https://user-images.githubusercontent.com/4870292/103588853-b936ff80-4f1c-11eb-8982-646901f5299e.png)

saya buat PR 1 lagi, solusi untuk masalah yang sama tapi dengan cara lain. 

mohon di review dan silahkan di pilih salah satu

terima kasih.