### PR TITLE
tambah fitur navigasi menuju halaman admin di header web publik issue #149

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -280,7 +280,7 @@ body{
 	background: linear-gradient(180deg, rgba(0, 43, 105, 1) 0%, rgba(0, 25, 142, 1) 50%, rgba(0, 43, 105, 1) 100%);
 	transition: 0.4s;
 	top: 0;
-	font-size: 17px;
+	font-size: 16px;
 	/* Big font size */
 	font-weight: bold;	
 	/* position: fixed; */

--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -38,11 +38,18 @@ function stickyFunction() {
 		navbar.classList.remove("sticky");
 	}
 	if (document.body.scrollTop > 30 || document.documentElement.scrollTop > 30) {
+		let mql = window.matchMedia('(max-width: 1199px) and (min-width: 992px)'); // media query lebar 1024px
+		if (mql.matches) {
+			navbar.style.fontSize = "11px";
+			navbar.style.padding = "0px";
+			logo.style.width = "150px";
+			return;
+		}
 		navbar.style.fontSize = "12px";
 		navbar.style.padding = "0px";
 		logo.style.width = "150px";
 	} else {
-		navbar.style.fontSize = "17px";
+		navbar.style.fontSize = "16px";
 		logo.style.width = "180px";
 	}
 }

--- a/resources/views/layouts/frontends/header.blade.php
+++ b/resources/views/layouts/frontends/header.blade.php
@@ -78,6 +78,7 @@
           @if (Sentinel::guest())
             <li><a href="{{ route('login') }}">LOGIN<span class="sr-only">(current)</span></a></li>
           @else
+          <li><a href="{{ route('dashboard.profil')}}">ADMIN</a></li>
           <li><a href="{{ route('logout') }}">LOGOUT<span class="sr-only">(current)</span></a></li>
           <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
             {{ csrf_field() }}


### PR DESCRIPTION
Menambah `<li><a>` dengan text ADMIN di navigation layout/frontends/header.blade.php. 
Pemilihan text ADMIN dengan alasan agar tidak terlalu panjang dan tetap satu baris di lebar layar 768px ketika scroll ke bawah.