### PR TITLE
perbaiki composer `dev`

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -252,7 +252,7 @@ return [
         // JWT Auth
         Tymon\JWTAuth\Providers\LaravelServiceProvider::class,
         // Debugbar
-        Barryvdh\Debugbar\ServiceProvider::class,
+        // Barryvdh\Debugbar\ServiceProvider::class,
 
         //Log Viewer
         Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider::class,


### PR DESCRIPTION
opsi `--no-dev` akan mengecualikan semua dependency pada `require-dev` (lihat composer.json) yang dikhususkan untuk proses development

fix #289 