### PR TITLE
hapus composer scripts `cs-check` & `cs-fix`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,8 +82,6 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate"
-        ],
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf"
+        ]
     }
 }


### PR DESCRIPTION
dihapus karena berhubungan dengan library yang sudah dihapus (laminas/laminas-coding-standard)
ref: https://github.com/OpenSID/OpenDK/commit/799a25adfe24de352a47306f0d6dca7563c09574