### PR TITLE
Sent logging error openDK to slack channel

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -35,6 +35,7 @@ use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 
 class Handler extends ExceptionHandler
 {
@@ -75,6 +76,16 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        $errorLog = collect([
+            [
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'code' => $exception->getCode(),
+            ]
+        ])->concat(collect($exception->getTrace())->take(2))->toArray();
+
+        Log::channel('slack')->error($exception->getMessage(), $errorLog);
+        
         return parent::render($request, $exception);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -31,6 +31,7 @@
 
 namespace App\Exceptions;
 
+use App\Jobs\LoggingErrorSlackJob;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
@@ -83,8 +84,10 @@ class Handler extends ExceptionHandler
                 'code' => $exception->getCode(),
             ]
         ])->concat(collect($exception->getTrace())->take(2))->toArray();
+        
+        $errorMessage = $exception->getMessage();
 
-        Log::channel('slack')->error($exception->getMessage(), $errorLog);
+        dispatch(new LoggingErrorSlackJob($errorMessage, $errorLog));
         
         return parent::render($request, $exception);
     }

--- a/app/Jobs/LoggingErrorSlackJob.php
+++ b/app/Jobs/LoggingErrorSlackJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class LoggingErrorSlackJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    private $errorMessage;
+    private $errorLog;
+    public function __construct($errorMessage, $errorLog)
+    {
+        $this->errorMessage = $errorMessage;
+        $this->errorLog = $errorLog;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        try {
+            Log::channel('slack')->error($this->errorMessage, $this->errorLog);
+        } catch (\Exception $e) {
+            dump($e->getMessage(), $e->getFile(), $e->getLine()). PHP_EOL;
+        }
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -29,6 +29,7 @@
  * @link       https://github.com/OpenSID/opendk
  */
 
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -85,10 +86,11 @@ return [
 
         'slack' => [
             'driver' => 'slack',
-            'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => 'Laravel Log',
+            'url' => env('LOG_SLACK_WEBHOOK_URL', 'default_webhook_url_here'),
+            'username' => 'Logging Error OpenDK',
             'emoji' => ':boom:',
-            'level' => 'critical',
+            'formatter' => JsonFormatter::class,
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
 
         'papertrail' => [

--- a/tests/Unit/SlackLoggingErrorTest.php
+++ b/tests/Unit/SlackLoggingErrorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class SlackLoggingErrorTest extends TestCase
+{
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     */
+    public function testSlackLoggingError()
+    {
+        Log::channel('slack')->info('Slack error test');
+        Log::channel('slack')->warning('Slack error test');
+        Log::channel('slack')->error('Slack error test');
+        Log::channel('slack')->critical('Slack error test');
+
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
[#326 ] - Error Pada OpenDK kirim ke channel slack

masukan webhook_url dan log_level pada file .env : 

`LOG_SLACK_WEBHOOK_URL=isi_webhook_url

dan untuk menentukan default value dari webhook_url edit file /config/logging.php :
 
`'slack' => [
  'driver' => 'slack',
  'url' => env('LOG_SLACK_WEBHOOK_URL', 'default_webhook_url_here'),
  'username' => 'Logging Error OpenDK',
  'emoji' => ':boom:',
  'formatter' => JsonFormatter::class,
  'level' => env('LOG_LEVEL', 'debug'),
],`

untuk melakukan testing, bisa run command di bawah, pada root directory:

`vendor/bin/phpunit --filter SlackLoggingErrorTest`


![WruK7s41Uk](https://user-images.githubusercontent.com/76574368/173732318-97073e60-f468-41ac-ae8e-fc6410c02a7a.png)
