### PR TITLE
update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,16 @@
 *.css linguist-vendored
 *.scss linguist-vendored
 *.js linguist-vendored
-CHANGELOG.md export-ignore
+
+/.docker export-ignore
+/.git* export-ignore
+/stubs export-ignore
+/tests export-ignore
+/.all-contributorsrc export-ignore
+/Agent export-ignore
+/docker-compose.yml export-ignore
+/package.json export-ignore
+/phpcs.xml export-ignore
+/.php-cs-fixer.xml export-ignore
+/phpunit.xml export-ignore
+/webpack.mix.js export-ignore

--- a/app/Http/Controllers/Informasi/PotensiController.php
+++ b/app/Http/Controllers/Informasi/PotensiController.php
@@ -69,7 +69,7 @@ class PotensiController extends Controller
         $page_title = 'Potensi';
         $page_description = 'Tambah Potensi';
 
-        return view('informasi.potensi.create', compact('page_title'));
+        return view('informasi.potensi.create', compact('page_title', 'page_description'));
     }
 
     public function store(PotensiRequest $request)
@@ -97,7 +97,7 @@ class PotensiController extends Controller
     public function show(Potensi $potensi)
     {
         $page_title       = 'Potensi';
-        $page_description = 'Potensi : ' . $potensi->nama_potensi;
+        $page_description = 'Detail Potensi';
 
         return view('informasi.potensi.show', compact('page_title', 'page_description', 'potensi'));
     }
@@ -105,7 +105,7 @@ class PotensiController extends Controller
     public function edit(Potensi $potensi)
     {
         $page_title       = 'Potensi';
-        $page_description = 'Ubah Potensi : ' . $potensi->nama_potensi;
+        $page_description = 'Ubah Potensi';
 
         return view('informasi.potensi.edit', compact('page_title', 'page_description', 'potensi'));
     }

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -24,3 +24,4 @@ Di rilis v2308.0.1 berisi perbaikan yang diminta Komunitas OpenDK.
 2. [#13](https://github.com/OpenSID/wiki-keamanan/issues/13) Perbaikan kemanan modul desa.
 3. [#11](https://github.com/OpenSID/wiki-keamanan/issues/11) Pembatasan input element HTML.
 4. [#786](https://github.com/OpenSID/OpenDK/issues/786) Pembatasan akses filemanager.
+5. [#801](https://github.com/OpenSID/OpenDK/issues/801) Penyesuaian .gitattributes.

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -11,7 +11,8 @@ Di rilis v2308.0.1 berisi perbaikan yang diminta Komunitas OpenDK.
 5. [#755](https://github.com/OpenSID/OpenDK/issues/755) Perbaikan slider contoh data awal.
 6. [#757](https://github.com/OpenSID/OpenDK/issues/757) Perbaikan tombol pada kolom aksi halaman regulasi.
 7. [#753](https://github.com/OpenSID/OpenDK/issues/753) Perbaikan validasi tambah/ubah pada modul dokumen.
-8. [#747](https://github.com/OpenSID/OpenDK/issues/747) Perbaikan breadcrumb pada halaman regulasi.
+8. [#747](https://github.com/OpenSID/OpenDK/issues/747) Perbaikan breadcrumb pada halaman admin regulasi.
+8. [#748](https://github.com/OpenSID/OpenDK/issues/748) Perbaikan breadcrumb pada halaman admin potensi.
 
 #### Teknis
 1. [#12](https://github.com/OpenSID/wiki-keamanan/issues/12) Perbaikan keamanan modul bantuan.


### PR DESCRIPTION
sudah ada di branch https://github.com/OpenSID/OpenDK/tree/gitattributes
hanya saja tidak diteruskan sampai sekarang (sejak 2022).

hasil arsip (ZIP) tanpa perubahan ini,
![image](https://github.com/OpenSID/OpenDK/assets/2387514/bf2e5a38-abf8-4296-b529-e35f32e91d61)

hasil dengan perubahan 
![image](https://github.com/OpenSID/OpenDK/assets/2387514/b14e003c-bb3a-4830-b2d2-e348cda4e800)

**php-cs-fixer** sudah diperbaiki

fix #801
