### PR TITLE
Fitur: deploy dev dan deploy rilis

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,26 +1,35 @@
 name: Deploy OpenDK Dev with Ansible
 
 on:
-  push:
-    branches:
-      - dev
+  pull_request:
+    branches: [dev]
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-opendk-dev
+  cancel-in-progress: true
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     name: Deploy OpenDK Dev to Production Server
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Ansible Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Deploy via SSH using appleboy/ssh-action
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
           username: ${{ secrets.CICD_SERVER_USER }}
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_IP_PORT }}
           script: |
+            set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
             ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk-dev.yml

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,13 +1,13 @@
-name: Deploy OpenDK with Ansible
+name: Deploy OpenDK Dev with Ansible
 
 on:
-  pull_request:
+  push:
     branches:
       - dev
 
 jobs:
   deploy:
-    name: Deploy to Production Server
+    name: Deploy OpenDK Dev to Production Server
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,8 +1,9 @@
 name: Deploy OpenDK with Ansible
 
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches:
+      - dev
 
 jobs:
   deploy:
@@ -21,5 +22,5 @@ jobs:
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_IP_PORT }}
           script: |
-            cd /opt/ansible
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk.yml
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk-dev.yml

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,9 +1,8 @@
 name: Deploy OpenDK Rilis with Ansible
 
 on:
-  pull_request:
-    branches:
-      - dev
+  release:
+    types: [published]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -1,0 +1,26 @@
+name: Deploy OpenDK Rilis with Ansible
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    name: Deploy OpenDK Rilis to Production Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v3
+
+      - name: Deploy via SSH using appleboy/ssh-action
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_IP_PORT }}
+          script: |
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk-rilis.yml

--- a/.github/workflows/deploy_rilis.yml
+++ b/.github/workflows/deploy_rilis.yml
@@ -4,8 +4,17 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-opendk-rilis
+  cancel-in-progress: true
+
 jobs:
   deploy:
+    # rilis dari branch 'master' & bukan prerelease
+    if: github.event.release.target_commitish == 'master' && github.event.release.prerelease == false
     name: Deploy OpenDK Rilis to Production Server
     runs-on: ubuntu-latest
 
@@ -14,12 +23,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Deploy via SSH using appleboy/ssh-action
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.CICD_SERVER_IP }}
           username: ${{ secrets.CICD_SERVER_USER }}
           key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
           port: ${{ secrets.CICD_SERVER_IP_PORT }}
           script: |
+            set -euo pipefail
             cd ${{ secrets.CICD_SERVER_PATH }}
-            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk-rilis.yml
+            ansible-playbook -i inventories/production/inventory.yml playbooks/deploy-opendk-rilis.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Deskripsi
Menambahkan fitur github action deploy otomatis via ansible

Apa yang berubah?
- Penyesuaian dengan github action
- Penyesuaian task ansible git fetch

### Ada 2 workflow:
**Deploy dev**
- Deploy ke branch `dev`, ketika ada event PR di merge ke `dev` dan status PR nya close
- Akan checkout ke branch `dev`
<img width="1093" height="512" alt="image1" src="https://github.com/user-attachments/assets/44ccb704-2787-47e2-8b27-bfe8d268dbca" />


**Deploy rilis**
- Deploy ke branch `master` dengan event rilis publish dan bukan prerelease
- Akan checkout ke `tag` rilis
<img width="1165" height="529" alt="image1-1" src="https://github.com/user-attachments/assets/a333c050-3554-4c67-bb10-d84c6a77ff07" />

