### PR TITLE
Fitur: deploy untuk menjalankan test case

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,65 @@
+name: Run Test Rilis with Ansible
+
+on:
+  release:
+    types: [published, edited, prereleased]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-run-test
+  cancel-in-progress: true
+
+jobs:
+  deploy-production:
+    # Hanya jalan kalau rilis dari branch master & bukan prerelease,
+    # serta event adalah published atau edited
+    if: |
+      github.event.release.target_commitish == 'master' &&
+      github.event.release.prerelease == false &&
+      (github.event.action == 'published' || github.event.action == 'edited')
+    name: Run Test (Release)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v4
+
+      - name: Deploy via SSH (Release)
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_IP_PORT }}
+          script: |
+            set -euo pipefail
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/staging/inventory.yml playbooks/run-tests-opendk.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"
+
+  deploy-prerelease:
+    # Hanya jalan kalau rilis dari branch master & prerelease = true,
+    # serta event adalah published atau edited
+    if: |
+      github.event.release.target_commitish == 'master' &&
+      github.event.release.prerelease == true &&
+      (github.event.action == 'published' || github.event.action == 'edited')
+    name: Run Test (Pre-Release)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Ansible Code
+        uses: actions/checkout@v4
+
+      - name: Deploy via SSH (Pre-Release)
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.CICD_SERVER_IP }}
+          username: ${{ secrets.CICD_SERVER_USER }}
+          key: ${{ secrets.CICD_SERVER_PRIVATE_KEY }}
+          port: ${{ secrets.CICD_SERVER_IP_PORT }}
+          script: |
+            set -euo pipefail
+            cd ${{ secrets.CICD_SERVER_PATH }}
+            ansible-playbook -i inventories/staging/inventory.yml playbooks/run-tests-opendk.yml --extra-vars "release_tag=${{ github.event.release.tag_name }}"


### PR DESCRIPTION
### Deskripsi
Menjalankan test case laravel di server staging otomatis via github action dan ansible

PR ini memerlukan PR dari ini:
- https://github.com/OpenSID/Ansible/pull/1

Kondisi:
- Menjalankan test case di server staging
- Github action ini akan berjalan ketika ada trigger rilis dan pra-rilis baik itu event publish atau edit
- Menggunakan tag rilis
- Mengirimkan hasil test case ke grup telegram yang ditentukan via bot layanan

```
on:
  release:
    types: [published, edited, prereleased]
```

```
deploy-production:
    # Hanya jalan kalau rilis dari branch master & bukan prerelease,
    # serta event adalah published atau edited
    if: |
      github.event.release.target_commitish == 'master' &&
      github.event.release.prerelease == false &&
      (github.event.action == 'published' || github.event.action == 'edited')
```

```
deploy-prerelease:
    # Hanya jalan kalau rilis dari branch master & prerelease = true,
    # serta event adalah published atau edited
    if: |
      github.event.release.target_commitish == 'master' &&
      github.event.release.prerelease == true &&
      (github.event.action == 'published' || github.event.action == 'edited')
```

<img width="862" height="993" alt="image" src="https://github.com/user-attachments/assets/faf23a05-0cff-4faf-8ea7-0a4ace5d9270" />

