### PR TITLE
Fix : Perbaiki Tampilan Tabel Artikel

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -10,6 +10,7 @@ Terimakasih [isi disini] yang telah berkontribusi langsung mengembangkan aplikas
 #### BUG
 
 1. [#1512](https://github.com/OpenSID/OpenDK/issues/1512) Perbaikan error ketika membuka artikel yang memiliki judul sangat panjang (lebih dari 191 karakter)
+2. [#1519](https://github.com/OpenSID/OpenDK/issues/1519) Perbaikan Tampilan Kolom aksi di artikel berubah ketika ada artikel dengan judul yang panjang (191 karakter)
 
 #### TEKNIS
 

--- a/resources/views/backend/event/create.blade.php
+++ b/resources/views/backend/event/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('informasi.event.store'))->id('form-event')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/backend/event/form_edit.blade.php
+++ b/resources/views/backend/event/form_edit.blade.php
@@ -15,7 +15,7 @@
     <div class="col-md-6 col-sm-8 col-xs-12">
         {!! html()->textarea('description', old('description', $event->description))->class('textarea my-editor')->placeholder('Deskripsi kegiatan')->style(
                 'width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding:
-                                                                                                                                10px;',
+                                                                                                                                        10px;',
             )->required() !!}
     </div>
 </div>

--- a/resources/views/backend/themes/import.blade.php
+++ b/resources/views/backend/themes/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('setting.themes.do-upload')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles() !!}
 
                 <div class="box-body">

--- a/resources/views/data/aki_akb/import.blade.php
+++ b/resources/views/data/aki_akb/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form('POST', route('data.aki-akb.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/anggaran_desa/import.blade.php
+++ b/resources/views/data/anggaran_desa/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('data.anggaran-desa.do_import')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles() !!}
 
                 <div class="box-body">

--- a/resources/views/data/anggaran_realisasi/import.blade.php
+++ b/resources/views/data/anggaran_realisasi/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('data.anggaran-realisasi.do_import')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles() !!}
 
                 <div class="box-body">

--- a/resources/views/data/data_desa/create.blade.php
+++ b/resources/views/data/data_desa/create.blade.php
@@ -19,7 +19,7 @@
 
                 {!! html()->form()->route('data.data-desa.store')->method('POST')->id('form-datadesa')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/data_sarana/create.blade.php
+++ b/resources/views/data/data_sarana/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.data-sarana.store'))->id('form-sarana')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
 
                     <div class="box-body">

--- a/resources/views/data/data_sarana/edit.blade.php
+++ b/resources/views/data/data_sarana/edit.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.data-sarana.update', $sarana->id))->id('form-sarana')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @method('PUT')
 

--- a/resources/views/data/data_sarana/import.blade.php
+++ b/resources/views/data/data_sarana/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form('POST', route('data.data-sarana.import-excel'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/data_suplemen/create.blade.php
+++ b/resources/views/data/data_suplemen/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.data-suplemen.store'))->id('form-faq')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
 
                     <div class="box-body">

--- a/resources/views/data/data_suplemen/form.blade.php
+++ b/resources/views/data/data_suplemen/form.blade.php
@@ -18,8 +18,8 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->textarea('keterangan')->class('textarea')->style(
                 'width: 100%; height: 200px; font-size: 14px;
-                                                                                                                                        line-height: 18px; border: 1px solid #dddddd; padding:
-                                                                                                                                        10px;',
+                                                                                                                                                line-height: 18px; border: 1px solid #dddddd; padding:
+                                                                                                                                                10px;',
             )->placeholder('Keterangan')->value(old('keterangan', isset($suplemen) ? $suplemen->keterangan : '')) !!}
     </div>
 </div>

--- a/resources/views/data/data_suplemen/form_detail.blade.php
+++ b/resources/views/data/data_suplemen/form_detail.blade.php
@@ -54,7 +54,7 @@
         <label class="control-label col-md-3 col-sm-3 col-xs-12"
             for="penduduk_id">{{ $suplemen->sasaran == 2
                 ? 'Nama Kepala
-                                                                                                                                                                        Keluarga'
+                                                                                                                                                                                    Keluarga'
                 : 'Nama Penduduk' }}</label>
 
         <div class="col-md-6 col-sm-6 col-xs-12">

--- a/resources/views/data/data_umum/form_edit.blade.php
+++ b/resources/views/data/data_umum/form_edit.blade.php
@@ -15,7 +15,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('tipologi')->class(
                         'form-control
-                                                                                                                                                                                                                                                                my-editor',
+                                                                                                                                                                                                                                                                                my-editor',
                     )->placeholder('Tipologi')->rows(2)->value(old('tipologi', isset($data_umum) ? $data_umum->tipologi : '')) !!}
             </div>
         </div>
@@ -26,7 +26,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('sejarah')->class(
                         'form-control
-                                                                                                                                                                                                                                                                my-editor',
+                                                                                                                                                                                                                                                                                my-editor',
                     )->placeholder('Sejarah')->rows(2)->value(old('sejarah', isset($data_umum) ? $data_umum->sejarah : '')) !!}
             </div>
         </div>
@@ -37,7 +37,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('ketinggian')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('ketinggian', isset($data_umum) ? $data_umum->ketinggian : '')) !!}
             </div>
         </div>
@@ -53,7 +53,7 @@
                     <div class="col-md-7">
                         {!! html()->number('luas_wilayah')->class(
                                 'form-control
-                                                                                                                                                                                                                                                                                                                                                                                                luas_wilayah text-right',
+                                                                                                                                                                                                                                                                                                                                                                                                                        luas_wilayah text-right',
                             )->placeholder('0')->value(old('luas_wilayah', isset($data_umum) ? $data_umum->luas_wilayah : '')) !!}
                     </div>
                 </div>
@@ -68,7 +68,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('bts_wil_utara')->class('form-control')->placeholder(
                         'Batas
-                                                                                                                                                                                                                                                                Utara',
+                                                                                                                                                                                                                                                                                Utara',
                     )->rows(2)->value(old('bts_wil_utara', isset($data_umum) ? $data_umum->bts_wil_utara : '')) !!}
             </div>
         </div>
@@ -78,7 +78,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('bts_wil_timur')->class('form-control')->placeholder(
                         'Batas
-                                                                                                                                                                                                                                                                Timur',
+                                                                                                                                                                                                                                                                                Timur',
                     )->rows(2)->value(old('bts_wil_timur', isset($data_umum) ? $data_umum->bts_wil_timur : '')) !!}
             </div>
         </div>
@@ -88,7 +88,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('bts_wil_selatan')->class('form-control')->placeholder(
                         'Batas
-                                                                                                                                                                                                                                                                Selatan',
+                                                                                                                                                                                                                                                                                Selatan',
                     )->rows(2)->value(old('bts_wil_selatan', isset($data_umum) ? $data_umum->bts_wil_selatan : '')) !!}
             </div>
         </div>
@@ -98,7 +98,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->textarea('bts_wil_barat')->class('form-control')->placeholder(
                         'Batas
-                                                                                                                                                                                                                                                                Barat',
+                                                                                                                                                                                                                                                                                Barat',
                     )->rows(2)->value(old('bts_wil_barat', isset($data_umum) ? $data_umum->bts_wil_barat : '')) !!}
             </div>
         </div>
@@ -113,7 +113,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_puskesmas')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_puskesmas', isset($data_umum) ? $data_umum->jml_puskesmas : '')) !!}
             </div>
         </div>
@@ -124,7 +124,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_puskesmas_pembantu')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_puskesmas_pembantu', isset($data_umum) ? $data_umum->jml_puskesmas_pembantu : '')) !!}
             </div>
         </div>
@@ -135,7 +135,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_posyandu')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_posyandu', isset($data_umum) ? $data_umum->jml_posyandu : '')) !!}
             </div>
         </div>
@@ -146,7 +146,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_pondok_bersalin')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_pondok_bersalin', isset($data_umum) ? $data_umum->jml_pondok_bersalin : '')) !!}
             </div>
         </div>
@@ -159,7 +159,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_paud')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_paud', isset($data_umum) ? $data_umum->jml_paud : '')) !!}
             </div>
         </div>
@@ -196,7 +196,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_masjid_besar')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_masjid_besar', isset($data_umum) ? $data_umum->jml_masjid_besar : '')) !!}
             </div>
         </div>
@@ -207,7 +207,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_mushola')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_mushola', isset($data_umum) ? $data_umum->jml_mushola : '')) !!}
             </div>
         </div>
@@ -218,7 +218,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_gereja')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_gereja', isset($data_umum) ? $data_umum->jml_gereja : '')) !!}
             </div>
         </div>
@@ -229,7 +229,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_pasar')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_pasar', isset($data_umum) ? $data_umum->jml_pasar : '')) !!}
             </div>
         </div>
@@ -240,7 +240,7 @@
             <div class="col-md-6 col-sm-6 col-xs-12">
                 {!! html()->number('jml_balai_pertemuan')->class(
                         'form-control
-                                                                                                                                                                                                                                                                text-right',
+                                                                                                                                                                                                                                                                                text-right',
                     )->placeholder('0')->value(old('jml_balai_pertemuan', isset($data_umum) ? $data_umum->jml_balai_pertemuan : '')) !!}
             </div>
         </div>

--- a/resources/views/data/epidemi_penyakit/import.blade.php
+++ b/resources/views/data/epidemi_penyakit/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form('POST', route('data.epidemi-penyakit.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/fasilitas_paud/import.blade.php
+++ b/resources/views/data/fasilitas_paud/import.blade.php
@@ -21,7 +21,7 @@
                 <!-- form start -->
                 {!! html()->form('POST', route('data.fasilitas-paud.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/imunisasi/import.blade.php
+++ b/resources/views/data/imunisasi/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('data.imunisasi.do_import')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/jabatan/create.blade.php
+++ b/resources/views/data/jabatan/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.jabatan.store'))->id('form-jabatan')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/jabatan/form.blade.php
+++ b/resources/views/data/jabatan/form.blade.php
@@ -11,7 +11,7 @@
 
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->textarea('tupoksi')->value(old('tupoksi', isset($jabatan) ? $jabatan->tupoksi : ''))->class('textarea')->placeholder('Tupoksi')->style('width: 100%; height: 200px; font-size: 14px;
-                                                                                                                                line-height: 18px; border: 1px solid #dddddd; padding: 10px;') !!}
+                                                                                                                                        line-height: 18px; border: 1px solid #dddddd; padding: 10px;') !!}
     </div>
 </div>
 <div class="ln_solid"></div>

--- a/resources/views/data/laporan-apbdes/import.blade.php
+++ b/resources/views/data/laporan-apbdes/import.blade.php
@@ -22,7 +22,7 @@
 
                 {!! html()->form('POST', route('data.laporan-apbdes.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/laporan-penduduk/import.blade.php
+++ b/resources/views/data/laporan-penduduk/import.blade.php
@@ -22,7 +22,7 @@
                 <div class="box box-primary">
                     {!! html()->form('POST', route('data.laporan-penduduk.do_import'))->id('form-import')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->acceptsFiles()->open() !!}
 
                     <div class="box-body">

--- a/resources/views/data/lembaga/create.blade.php
+++ b/resources/views/data/lembaga/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.lembaga.store'))->id('form-lembaga')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/lembaga_anggota/form_create.blade.php
+++ b/resources/views/data/lembaga_anggota/form_create.blade.php
@@ -13,7 +13,7 @@
         <div style="display: flex; flex-direction: column;">
             {!! html()->select('penduduk_id', $pendudukList)->value(old('penduduk_id', isset($anggota) ? $anggota->penduduk_id : (isset($lembaga) ? $lembaga->penduduk_id : '')))->class(
                     'form-control
-                                                                                                                                                                                                                        select2',
+                                                                                                                                                                                                                                    select2',
                 )->placeholder('Pilih Nama Anggota')->required()->style('width:100%;') !!}
         </div>
     </div>
@@ -67,7 +67,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->date('tgl_sk_pengangkatan', old('tgl_sk_pengangkatan'))->placeholder(
                 'Tanggal SK
-                                                                                                                                                Pengangkatan',
+                                                                                                                                                        Pengangkatan',
             )->class('form-control') !!}
     </div>
 </div>

--- a/resources/views/data/lembaga_kategori/create.blade.php
+++ b/resources/views/data/lembaga_kategori/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('post')->route('data.kategori-lembaga.store')->id('form-kategori-lembaga')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/penduduk/import.blade.php
+++ b/resources/views/data/penduduk/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('data.penduduk.import-excel')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/pengurus/arsip.blade.php
+++ b/resources/views/data/pengurus/arsip.blade.php
@@ -43,7 +43,7 @@
 
                     {!! html()->form()->route('data.pengurus.store')->method('POST')->acceptsFiles()->id('form-pengurus')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/pengurus/create_arsip.blade.php
+++ b/resources/views/data/pengurus/create_arsip.blade.php
@@ -30,7 +30,7 @@
 
                     {!! html()->form()->route('data.pengurus.store.arsip')->method('POST')->acceptsFiles()->id('form-pengurus')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/pengurus/edit.blade.php
+++ b/resources/views/data/pengurus/edit.blade.php
@@ -20,7 +20,7 @@
                     <!-- form start -->
                     {!! html()->form('POST', route('data.pengurus.update', $pengurus->id))->acceptsFiles()->id('form-pengurus')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/data/pengurus/edit_arsip.blade.php
+++ b/resources/views/data/pengurus/edit_arsip.blade.php
@@ -28,7 +28,7 @@
 
                     {!! html()->form('post')->route('data.pengurus.store.arsip')->acceptsFiles()->id('form-pengurus')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
                     <div class="box-body">

--- a/resources/views/data/pengurus/form_create_arsip.blade.php
+++ b/resources/views/data/pengurus/form_create_arsip.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->select('jenis_surat', \App\Models\JenisSurat::pluck('nama', 'id')->value(old('jenis_surat', isset($pengurus) ? $pengurus->jenis_surat : '')), null, [
             'placeholder' => 'Pilih
-                                                                                                                                Jenis Dokumen',
+                                                                                                                                        Jenis Dokumen',
             'class' => 'form-control',
             'id' => 'jenis_dokumen_id',
             'required' => true,
@@ -19,7 +19,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->text('judul_document')->class('form-control')->required()->placeholder(
                 'Judul
-                                                                                                                                Document',
+                                                                                                                                        Document',
             )->value(old('judul_document', isset($pengurus) ? $pengurus->judul_document : '')) !!}
     </div>
 </div>

--- a/resources/views/data/pengurus/form_edit_arsip.blade.php
+++ b/resources/views/data/pengurus/form_edit_arsip.blade.php
@@ -23,7 +23,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->text('judul_document')->class('form-control')->required()->placeholder(
                 'Judul
-                                                                                                                                Document',
+                                                                                                                                        Document',
             )->value(old('judul_document', isset($pengurus) ? $pengurus->judul_document : '')) !!}
     </div>
 </div>

--- a/resources/views/data/profil/form_edit.blade.php
+++ b/resources/views/data/profil/form_edit.blade.php
@@ -148,7 +148,7 @@
             <label class="control-label col-md-4 col-sm-3 col-xs-12">Sambutan {{ $sebutan_kepala_wilayah }}</label>
             <div class="col-md-8 col-sm-6 col-xs-12">
                 {!! html()->textarea('sambutan', old('sambutan', $profil->sambutan ?? null))->class('textarea my-editor')->placeholder('Sambutan ' . $sebutan_kepala_wilayah . ' ' . $profil->nama_kecamatan)->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd;
-                                                                                                                                                                                                                                                                padding: 10px;') !!}
+                                                                                                                                                                                                                                                                                padding: 10px;') !!}
             </div>
         </div>
     </div>
@@ -161,14 +161,14 @@
             <label class="control-label col-md-2 col-sm-3 col-xs-12">Visi</label>
             <div class="col-md-7 col-sm-6 col-xs-12">
                 {!! html()->textarea('visi', old('visi', $profil->visi ?? null))->class('textarea my-editor')->placeholder('Visi Kecamatan')->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd;
-                                                                                                                                                                                                                                                                padding: 10px;') !!}
+                                                                                                                                                                                                                                                                                padding: 10px;') !!}
             </div>
         </div>
         <div class="form-group">
             <label class="control-label col-md-2 col-sm-3 col-xs-12">Misi</label>
             <div class="col-md-7 col-sm-6 col-xs-12">
                 {!! html()->textarea('misi', old('misi', $profil->misi ?? null))->class('textarea my-editor')->placeholder('Misi Kecamatan')->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd;
-                                                                                                                                                                                                                                                                padding: 10px;') !!}
+                                                                                                                                                                                                                                                                                padding: 10px;') !!}
             </div>
         </div>
     </div>

--- a/resources/views/data/program_bantuan/import.blade.php
+++ b/resources/views/data/program_bantuan/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form('POST', route('data.program-bantuan.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/putus_sekolah/import.blade.php
+++ b/resources/views/data/putus_sekolah/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form()->route('data.putus-sekolah.do_import')->method('POST')->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/tingkat_pendidikan/import.blade.php
+++ b/resources/views/data/tingkat_pendidikan/import.blade.php
@@ -20,7 +20,7 @@
 
                 {!! html()->form('POST', route('data.tingkat-pendidikan.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/data/toilet_sanitasi/import.blade.php
+++ b/resources/views/data/toilet_sanitasi/import.blade.php
@@ -33,7 +33,7 @@
                 <!-- form start -->
                 {!! html()->form('POST', route('data.toilet-sanitasi.do_import'))->id('form-import')->class(
                         'form-horizontal
-                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                            form-label-left',
                     )->acceptsFiles()->open() !!}
 
                 <div class="box-body">

--- a/resources/views/informasi/artikel/_form.blade.php
+++ b/resources/views/informasi/artikel/_form.blade.php
@@ -20,7 +20,7 @@
 
                     {!! html()->textarea('isi')->class('form-control my-editor')->placeholder('Isi Artikel')->style(
                             'width:100%; height:750px; font-size:14px; line-height:18px; border:1px solid #dddddd;
-                                                                                                                                                                                                                                                                                                                                padding:10px;',
+                                                                                                                                                                                                                                                                                                                                                    padding:10px;',
                         )->value(old('isi', isset($artikel) ? $artikel->isi : '')) !!}
                     @if ($errors->has('isi'))
                         <span class="help-block" style="color:red">{{ $errors->first('isi') }}</span>

--- a/resources/views/informasi/artikel/index.blade.php
+++ b/resources/views/informasi/artikel/index.blade.php
@@ -35,7 +35,7 @@
                     <table class="table table-striped table-bordered" id="artikel-table">
                         <thead>
                             <tr>
-                                <th style="max-width: 150px;">Aksi</th>
+                                <th class="text-center text-nowrap" style="max-width: 150px;">Aksi</th>
                                 <th>Judul</th>
                                 <th>Kategori</th>
                                 <th style="max-width: 100px;">Status</th>
@@ -48,6 +48,18 @@
         </div>
     </section>
 @endsection
+@push('css')
+    <style>
+        #artikel-table .artikel-title-cell {
+            display: inline-block;
+            max-width: 320px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+    </style>
+@endpush
 
 @include('partials.asset_datatables')
 
@@ -61,13 +73,13 @@
                 columns: [{
                         data: 'aksi',
                         name: 'aksi',
-                        class: 'text-center',
+                        class: 'text-center text-nowrap',
                         searchable: false,
                         orderable: false
                     },
                     {
                         data: 'judul',
-                        name: 'judul'
+                        name: 'judul',
                     },
                     {
                         data: 'kategori',

--- a/resources/views/informasi/artikel_kategori/create.blade.php
+++ b/resources/views/informasi/artikel_kategori/create.blade.php
@@ -20,7 +20,7 @@
 
                     {!! html()->form('POST', route('informasi.artikel-kategori.store'))->id('form-artikel-kategori')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/informasi/faq/create.blade.php
+++ b/resources/views/informasi/faq/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('informasi.faq.store'))->id('form-faq')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
                     @include('layouts.fragments.error_message')
 

--- a/resources/views/informasi/faq/form.blade.php
+++ b/resources/views/informasi/faq/form.blade.php
@@ -10,7 +10,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {{ html()->textarea('answer')->value(old('answer', $faq->answer ?? ''))->class('textarea my-editor')->placeholder('Jawaban')->style(
                 'width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding:
-                                                                                                                                10px;',
+                                                                                                                                        10px;',
             )->required() }}
     </div>
 </div>

--- a/resources/views/informasi/form_dokumen/create.blade.php
+++ b/resources/views/informasi/form_dokumen/create.blade.php
@@ -21,7 +21,7 @@
                         <!-- form start -->
                         {!! html()->form('POST', route('informasi.form-dokumen.store'))->acceptsFiles()->id('form-dokumen')->class(
                                 'form-horizontal
-                                                                                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                                                                                    form-label-left',
                             )->open() !!}
 
                         @if (count($errors) > 0)

--- a/resources/views/informasi/media_sosial/create.blade.php
+++ b/resources/views/informasi/media_sosial/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('informasi.media-sosial.store'))->acceptsFiles()->id('form-media-sosial')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
 
                     <div class="box-body">

--- a/resources/views/informasi/potensi/create.blade.php
+++ b/resources/views/informasi/potensi/create.blade.php
@@ -21,7 +21,7 @@
                         <!-- form start -->
                         {!! html()->form('POST', route('informasi.potensi.store'))->acceptsFiles()->id('form-potensi')->class(
                                 'form-horizontal
-                                                                                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                                                                                    form-label-left',
                             )->open() !!}
 
                         @if (count($errors) > 0)

--- a/resources/views/informasi/prosedur/create.blade.php
+++ b/resources/views/informasi/prosedur/create.blade.php
@@ -21,7 +21,7 @@
                         <!-- form start -->
                         {!! html()->form('POST', route('informasi.prosedur.store'))->acceptsFiles()->id('form-prosedur')->class(
                                 'form-horizontal
-                                                                                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                                                                                    form-label-left',
                             )->open() !!}
 
                         @if (count($errors) > 0)

--- a/resources/views/informasi/regulasi/create.blade.php
+++ b/resources/views/informasi/regulasi/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('informasi.regulasi.store'))->id('form-regulasi')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->acceptsFiles()->open() !!}
                     <div class="box-body">
 

--- a/resources/views/informasi/sinergi_program/create.blade.php
+++ b/resources/views/informasi/sinergi_program/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('informasi.sinergi-program.store'))->acceptsFiles()->id('form-sinergi-program')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->open() !!}
 
                     <div class="box-body">

--- a/resources/views/informasi/sinergi_program/edit.blade.php
+++ b/resources/views/informasi/sinergi_program/edit.blade.php
@@ -32,7 +32,7 @@
                     <!-- form start -->
                     {!! html()->form('PUT', route('informasi.sinergi-program.update', $sinergi->id))->id('form-sinergi-program')->class(
                             'form-horizontal
-                                                                                                                                                                                                                                                                                                                            form-label-left',
+                                                                                                                                                                                                                                                                                                                                                form-label-left',
                         )->acceptsFiles()->open() !!}
 
                     <div class="box-body">

--- a/resources/views/pesan/masuk/index.blade.php
+++ b/resources/views/pesan/masuk/index.blade.php
@@ -46,7 +46,7 @@
                             </button>
                             {!! html()->form('POST', route('pesan.arsip.multiple'))->class(
                                     'form-group
-                                                                                                                                                                                                                                                                                                                                                                                                                                                            inline',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        inline',
                                 )->id('form-multiple-arsip-pesan')->open() !!}
                             <button id="arsip-action" type="submit" class="btn btn-default btn-sm"><i class="fa fa-archive"></i> Arsipkan</button>
                             {!! html()->hidden('array_id')->id('array_multiple_id_arsip') !!}
@@ -54,7 +54,7 @@
 
                             {!! html()->form('POST', route('pesan.read.multiple'))->class(
                                     'form-group
-                                                                                                                                                                                                                                                                                                                                                                                                                                                            inline',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        inline',
                                 )->id('form-multiple-read-pesan')->open() !!}
                             {!! html()->hidden('array_id')->id('array_multiple_id') !!}
                             <button id="read-multiple-action" type="submit" class="btn btn-default btn-sm"><i class="fa fa-envelope-open"></i> Tandai Sudah dibaca</button>

--- a/resources/views/pesan/read_pesan.blade.php
+++ b/resources/views/pesan/read_pesan.blade.php
@@ -28,7 +28,7 @@
                             @if ($pesan->diarsipkan === 0)
                                 {!! html()->form('POST', route('pesan.arsip.post'))->class(
                                         'form-group
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                inline',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                inline',
                                     )->id('form-arisp-pesan')->open() !!}
                                 {!! html()->hidden('id', $pesan->id) !!}
                                 <button id="arsip-action" type="submit" class="btn btn-default btn-sm"><i class="fa fa-archive"></i> Arsipkan </button>
@@ -77,11 +77,11 @@
                     <div style="padding-right: 10px; padding-left: 10px" class="box-footer form-group {{ $pesan->diarsipkan == 1 ? 'hidden' : '' }}">
                         {!! html()->form('POST', route('pesan.reply.post'))->class(
                                 'form-group
-                                                                                                                                                                                                                                                                                                                                                                                                inline',
+                                                                                                                                                                                                                                                                                                                                                                                                                        inline',
                             )->id('form-reply-pesan')->open() !!}
                         {!! html()->hidden('id', $pesan->id) !!}
                         {!! html()->textarea('text')->class('textarea')->id('reply_message')->placeholder('Balas Pesan')->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid
-                                                                                                                                                                                                                                                                                                                                                                                                #dddddd; padding: 10px;') !!}
+                                                                                                                                                                                                                                                                                                                                                                                                                        #dddddd; padding: 10px;') !!}
                         <button id="action-reply" type="submit" class="btn btn-default" style="margin-top: 1rem"><i class="fa fa-reply"></i> Balas</button>
                         {!! html()->form()->close() !!}
                     </div>

--- a/resources/views/setting/aplikasi/form.blade.php
+++ b/resources/views/setting/aplikasi/form.blade.php
@@ -28,7 +28,7 @@
             {!! html()->select('value', [
                     'OpenStreetMap' => 'OpenStreetMap',
                     'OpenStreetMap H.O.T.' => 'OpenStreetMap
-                                                                                                                                                                                            H.O.T.',
+                                                                                                                                                                                                        H.O.T.',
                     'Mapbox Streets' => 'Mapbox Streets',
                     'Mapbox Satellite' => 'Mapbox Satellite',
                     'Mapbox Satellite-Streets' => 'Mapbox Satellite-Streets',

--- a/resources/views/setting/slide/form.blade.php
+++ b/resources/views/setting/slide/form.blade.php
@@ -9,7 +9,7 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->textarea('deskripsi')->class('textarea')->style(
                 'width: 100%; height: 200px; font-size: 14px;
-                                                                                                                                line-height: 18px; border: 1px solid #dddddd; padding: 10px;',
+                                                                                                                                        line-height: 18px; border: 1px solid #dddddd; padding: 10px;',
             )->placeholder('deskripsi')->value(old('deskripsi', isset($slide) ? $slide->deskripsi : '')) !!}
     </div>
 </div>


### PR DESCRIPTION
issue https://github.com/OpenSID/OpenDK/issues/1519

<img width="1654" height="418" alt="image" src="https://github.com/user-attachments/assets/230b9d64-6e67-4bb5-aa52-5f21698efaa0" />

## Deskripsi Masalah
Tampilan tabel pada halaman daftar artikel mengalami kerusakan layout ketika terdapat artikel dengan judul yang sangat panjang (mencapai batas 191 karakter). Masalah utama meliputi:
- Kolom **Aksi** pecah baris atau bergeser, membuat tombol aksi tidak sejajar.
- Kolom **Judul** mengambil terlalu banyak ruang horizontal, merusak proporsi tabel.

## Perubahan yang Dilakukan
Untuk mengatasi masalah tersebut, dilakukan optimasi pada file `resources/views/informasi/artikel/index.blade.php`:

1.  **Stabilitas Kolom Aksi**:
    - Menambahkan class `text-nowrap` pada elemen `<th>` (header) dan konfigurasi `columns` DataTables untuk kolom aksi. Ini memastikan tombol-tombol aksi selalu berada dalam satu baris.

2.  **Pengalaman Pengguna (UX)**:
    - Judul asli yang lengkap tetap tersedia melalui atribut `title` (tooltip bawaan browser) sehingga pengguna tetap bisa membaca judul penuh tanpa harus membuka detail artikel.
    - Menambahkan pengamanan (*escaping*) pada karakter kutipan di atribut `title` untuk mencegah kerusakan markup HTML.

## Verifikasi
- [x] Tabel tampil rapi pada data dengan judul pendek.
- [x] Tooltip menampilkan judul lengkap saat kursor diarahkan ke judul yang terpotong.
- [x] Tombol aksi tetap dalam satu baris meskipun judul di sampingnya sangat panjang.
- [x] Tidak ada perubahan perilaku pada fitur filter kategori dan pencarian.