### PR TITLE
perbaiki masalah cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ mcp.json
 /.opencode
 /vendor-backup
 
-nul
+.env.testing

--- a/app/Events/FormDokumenChanged.php
+++ b/app/Events/FormDokumenChanged.php
@@ -29,51 +29,27 @@
  * @link       https://github.com/OpenSID/opendk
  */
 
-namespace App\Models;
+namespace App\Events;
 
-use App\Events\FormDokumenChanged;
-use App\Traits\HandlesResourceDeletion;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\FormDokumen;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
-class FormDokumen extends Model
+class FormDokumenChanged
 {
-    use HandlesResourceDeletion;
+    use Dispatchable;
+    use SerializesModels;
 
-    protected $table = 'das_form_dokumen';
-
-    /**
-     * Register model lifecycle hooks.
-     */
-    protected static function booted(): void
-    {
-        static::created(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-        static::updated(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-        static::deleted(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-    }
-
-    protected $fillable = [
-        'nama_dokumen',
-        'description',
-        'file_dokumen',
-        'jenis_dokumen_id',
-        'jenis_dokumen',
-        'is_published',
-        'published_at',
-        'retention_days',
-        'expired_at'
-    ];
+    public FormDokumen $formDokumen;
 
     /**
-     * Daftar field-file yang harus dihapus.
+     * Create a new event instance.
      *
-     * @var array
+     * @param  FormDokumen  $formDokumen
+     * @return void
      */
-    protected $resources = [
-        'file_dokumen',
-    ];
-
-    public function jenisDokumen()
+    public function __construct(FormDokumen $formDokumen)
     {
-        return $this->belongsTo(JenisDokumen::class, 'jenis_dokumen_id');
+        $this->formDokumen = $formDokumen;
     }
 }

--- a/app/Events/PotensiChanged.php
+++ b/app/Events/PotensiChanged.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Potensi;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PotensiChanged
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public $potensi;
+
+    public function __construct(Potensi $potensi)
+    {
+        $this->potensi = $potensi;
+    }
+}

--- a/app/Events/RegulasiChanged.php
+++ b/app/Events/RegulasiChanged.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Regulasi;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RegulasiChanged
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public $regulasi;
+
+    public function __construct(Regulasi $regulasi)
+    {
+        $this->regulasi = $regulasi;
+    }
+}

--- a/app/Http/Controllers/Api/Frontend/AlbumController.php
+++ b/app/Http/Controllers/Api/Frontend/AlbumController.php
@@ -32,10 +32,10 @@
 namespace App\Http\Controllers\Api\Frontend;
 
 use App\Repositories\AlbumApiRepository;
+use App\Services\CacheService;
 use App\Transformers\AlbumTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Spatie\Fractal\Fractal;
 
 /**
@@ -58,11 +58,14 @@ use Spatie\Fractal\Fractal;
 class AlbumController extends BaseController
 {
     protected AlbumApiRepository $albumApiRepository;
+    protected CacheService $cacheService;
 
     public function __construct(
-        AlbumApiRepository $albumApiRepository
+        AlbumApiRepository $albumApiRepository,
+        CacheService $cacheService
     ) {
         $this->albumApiRepository = $albumApiRepository;
+        $this->cacheService = $cacheService;
         $this->prefix = config('theme-api.album.cache_prefix', 'album:api');
     }
 
@@ -161,8 +164,8 @@ class AlbumController extends BaseController
         $params = $request->only(['page', 'per_page', 'filter', 'fields', 'search', 'sort', 'order', 'include']);
         $cacheKey = $this->getCacheKey('index', $params);
         
-        return Cache::remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
+        return $this->cacheService->remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
             return $this->fractal($this->albumApiRepository->data(), new AlbumTransformer, 'album');    
-        });
+        }, $this->prefix, 'album');
     }    
 }

--- a/app/Http/Controllers/Api/Frontend/FormDokumenController.php
+++ b/app/Http/Controllers/Api/Frontend/FormDokumenController.php
@@ -32,10 +32,10 @@
 namespace App\Http\Controllers\Api\Frontend;
 
 use App\Repositories\FormDokumenApiRepository;
+use App\Services\CacheService;
 use App\Transformers\FormDokumenTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Spatie\Fractal\Fractal;
 
 /**
@@ -58,11 +58,14 @@ use Spatie\Fractal\Fractal;
 class FormDokumenController extends BaseController
 {
     protected FormDokumenApiRepository $formDokumenApiRepository;
+    protected CacheService $cacheService;
 
     public function __construct(
-        FormDokumenApiRepository $formDokumenApiRepository
+        FormDokumenApiRepository $formDokumenApiRepository,
+        CacheService $cacheService
     ) {
         $this->formDokumenApiRepository = $formDokumenApiRepository;
+        $this->cacheService = $cacheService;
         $this->prefix = config('theme-api.form_dokumen.cache_prefix', 'form_dokumen:api');
     }
 
@@ -188,8 +191,8 @@ class FormDokumenController extends BaseController
         $params = $request->only(['page', 'per_page', 'filter', 'fields', 'search', 'sort', 'order', 'include']);
         $cacheKey = $this->getCacheKey('index', $params);
 
-        return Cache::remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
+        return $this->cacheService->remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
             return $this->fractal($this->formDokumenApiRepository->data(), new FormDokumenTransformer, 'formdokumen');
-        });
+        }, $this->prefix, 'form_dokumen');
     }
 }

--- a/app/Http/Controllers/Api/Frontend/GaleriController.php
+++ b/app/Http/Controllers/Api/Frontend/GaleriController.php
@@ -32,10 +32,10 @@
 namespace App\Http\Controllers\Api\Frontend;
 
 use App\Repositories\GaleriApiRepository;
+use App\Services\CacheService;
 use App\Transformers\GaleriTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Spatie\Fractal\Fractal;
 
 /**
@@ -58,11 +58,14 @@ use Spatie\Fractal\Fractal;
 class GaleriController extends BaseController
 {
     protected GaleriApiRepository $galeriApiRepository;
+    protected CacheService $cacheService;
 
     public function __construct(
-        GaleriApiRepository $galeriApiRepository
+        GaleriApiRepository $galeriApiRepository,
+        CacheService $cacheService
     ) {
         $this->galeriApiRepository = $galeriApiRepository;
+        $this->cacheService = $cacheService;
         $this->prefix = config('theme-api.galeri.cache_prefix', 'galeri:api');
     }
 
@@ -171,8 +174,8 @@ class GaleriController extends BaseController
         $params = $request->only(['page', 'per_page', 'filter', 'fields', 'search', 'sort', 'order', 'include']);
         $cacheKey = $this->getCacheKey('index', $params);
         
-        return Cache::remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
+        return $this->cacheService->remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
             return $this->fractal($this->galeriApiRepository->data(), new GaleriTransformer, 'galeri');    
-        });
+        }, $this->prefix, 'galeri');
     }    
 }

--- a/app/Http/Controllers/Api/Frontend/PotensiController.php
+++ b/app/Http/Controllers/Api/Frontend/PotensiController.php
@@ -32,10 +32,10 @@
 namespace App\Http\Controllers\Api\Frontend;
 
 use App\Repositories\PotensiApiRepository;
+use App\Services\CacheService;
 use App\Transformers\PotensiTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Spatie\Fractal\Fractal;
 
 /**
@@ -58,11 +58,14 @@ use Spatie\Fractal\Fractal;
 class PotensiController extends BaseController
 {
     protected PotensiApiRepository $potensiApiRepository;
+    protected CacheService $cacheService;
 
     public function __construct(
-        PotensiApiRepository $potensiApiRepository
+        PotensiApiRepository $potensiApiRepository,
+        CacheService $cacheService
     ) {
         $this->potensiApiRepository = $potensiApiRepository;
+        $this->cacheService = $cacheService;
         $this->prefix = config('theme-api.potensi.cache_prefix', 'potensi:api');
     }
 
@@ -179,8 +182,8 @@ class PotensiController extends BaseController
         $params = $request->only(['page', 'per_page', 'filter', 'fields', 'search', 'sort', 'order', 'include']);
         $cacheKey = $this->getCacheKey('index', $params);
 
-        return Cache::remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
+        return $this->cacheService->remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
             return $this->fractal($this->potensiApiRepository->data(), new PotensiTransformer, 'potensi');
-        });
+        }, $this->prefix, 'potensi');
     }
 }

--- a/app/Http/Controllers/Api/Frontend/RegulasiController.php
+++ b/app/Http/Controllers/Api/Frontend/RegulasiController.php
@@ -32,10 +32,10 @@
 namespace App\Http\Controllers\Api\Frontend;
 
 use App\Repositories\RegulasiApiRepository;
+use App\Services\CacheService;
 use App\Transformers\RegulasiTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Spatie\Fractal\Fractal;
 
 /**
@@ -58,11 +58,14 @@ use Spatie\Fractal\Fractal;
 class RegulasiController extends BaseController
 {
     protected RegulasiApiRepository $regulasiApiRepository;
+    protected CacheService $cacheService;
 
     public function __construct(
-        RegulasiApiRepository $regulasiApiRepository
+        RegulasiApiRepository $regulasiApiRepository,
+        CacheService $cacheService
     ) {
         $this->regulasiApiRepository = $regulasiApiRepository;
+        $this->cacheService = $cacheService;
         $this->prefix = config('theme-api.regulasi.cache_prefix', 'regulasi:api');
     }
 
@@ -178,8 +181,8 @@ class RegulasiController extends BaseController
         $params = $request->only(['page', 'per_page', 'filter', 'fields', 'search', 'sort', 'order', 'include']);
         $cacheKey = $this->getCacheKey('index', $params);
 
-        return Cache::remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
+        return $this->cacheService->remember($cacheKey, $this->getCacheDuration(), function () use ($request) {
             return $this->fractal($this->regulasiApiRepository->data(), new RegulasiTransformer, 'regulasi');
-        });
+        }, $this->prefix, 'regulasi');
     }
 }

--- a/app/Listeners/ClearFormDokumenCacheListener.php
+++ b/app/Listeners/ClearFormDokumenCacheListener.php
@@ -29,51 +29,29 @@
  * @link       https://github.com/OpenSID/opendk
  */
 
-namespace App\Models;
+namespace App\Listeners;
 
 use App\Events\FormDokumenChanged;
-use App\Traits\HandlesResourceDeletion;
-use Illuminate\Database\Eloquent\Model;
+use App\Services\CacheService;
+use Illuminate\Support\Facades\Log;
 
-class FormDokumen extends Model
+class ClearFormDokumenCacheListener
 {
-    use HandlesResourceDeletion;
-
-    protected $table = 'das_form_dokumen';
-
     /**
-     * Register model lifecycle hooks.
-     */
-    protected static function booted(): void
-    {
-        static::created(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-        static::updated(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-        static::deleted(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
-    }
-
-    protected $fillable = [
-        'nama_dokumen',
-        'description',
-        'file_dokumen',
-        'jenis_dokumen_id',
-        'jenis_dokumen',
-        'is_published',
-        'published_at',
-        'retention_days',
-        'expired_at'
-    ];
-
-    /**
-     * Daftar field-file yang harus dihapus.
+     * Handle the event.
      *
-     * @var array
+     * @return void
      */
-    protected $resources = [
-        'file_dokumen',
-    ];
-
-    public function jenisDokumen()
+    public function handle(FormDokumenChanged $event)
     {
-        return $this->belongsTo(JenisDokumen::class, 'jenis_dokumen_id');
+        try {
+            $cacheService = app(CacheService::class);
+            $prefix = config('theme-api.form_dokumen.cache_prefix', 'form_dokumen:api');
+            $cacheService->removeCachePrefix($prefix);
+        } catch (\Exception $e) {
+            Log::error('Exception occurred while clearing form dokumen cache', [
+                'message' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Listeners/ClearPotensiCacheListener.php
+++ b/app/Listeners/ClearPotensiCacheListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\PotensiChanged;
+use App\Services\CacheService;
+use Illuminate\Support\Facades\Log;
+
+class ClearPotensiCacheListener
+{
+    public function handle(PotensiChanged $event)
+    {
+        try {
+            $cacheService = app(CacheService::class);
+            $prefix = config('theme-api.potensi.cache_prefix', 'potensi:api');
+            $cacheService->removeCachePrefix($prefix);
+        } catch (\Exception $e) {
+            Log::error('Exception occurred while clearing potensi cache', [
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Listeners/ClearRegulasiCacheListener.php
+++ b/app/Listeners/ClearRegulasiCacheListener.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\RegulasiChanged;
+use App\Services\CacheService;
+use Illuminate\Support\Facades\Log;
+
+class ClearRegulasiCacheListener
+{
+    public function handle(RegulasiChanged $event)
+    {
+        try {
+            $cacheService = app(CacheService::class);
+            $prefix = config('theme-api.regulasi.cache_prefix', 'regulasi:api');
+            $cacheService->removeCachePrefix($prefix);
+        } catch (\Exception $e) {
+            Log::error('Exception occurred while clearing regulasi cache', [
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Models/Potensi.php
+++ b/app/Models/Potensi.php
@@ -31,6 +31,7 @@
 
 namespace App\Models;
 
+use App\Events\PotensiChanged;
 use App\Traits\HandlesResourceDeletion;
 use Illuminate\Database\Eloquent\Model;
 
@@ -39,6 +40,13 @@ class Potensi extends Model
     use HandlesResourceDeletion;
 
     protected $table = 'das_potensi';
+
+    protected static function booted(): void
+    {
+        static::created(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
+        static::updated(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
+        static::deleted(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
+    }
 
     protected $fillable = [
         'kategori_id',

--- a/app/Models/Regulasi.php
+++ b/app/Models/Regulasi.php
@@ -31,6 +31,7 @@
 
 namespace App\Models;
 
+use App\Events\RegulasiChanged;
 use App\Traits\HandlesResourceDeletion;
 use Illuminate\Database\Eloquent\Model;
 
@@ -39,6 +40,13 @@ class Regulasi extends Model
     use HandlesResourceDeletion;
 
     protected $table = 'das_regulasi';
+
+    protected static function booted(): void
+    {
+        static::created(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
+        static::updated(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
+        static::deleted(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
+    }
 
     protected $fillable = [
         'kecamatan_id',

--- a/app/Observers/AlbumObserver.php
+++ b/app/Observers/AlbumObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Album;
+use App\Services\CacheService;
 use Illuminate\Support\Facades\Storage;
 
 class AlbumObserver
@@ -15,7 +16,7 @@ class AlbumObserver
      */
     public function created(Album $album)
     {
-        //
+        $this->clearCache();
     }
 
     /**
@@ -29,6 +30,8 @@ class AlbumObserver
         if ($album->isDirty('gambar')) {
             Storage::disk('public')->delete($album->getOriginal('gambar'));
         }
+
+        $this->clearCache();
     }
 
     /**
@@ -42,6 +45,8 @@ class AlbumObserver
         if (!is_null($album->gambar)) {
             Storage::disk('public')->delete($album->gambar);
         }
+
+        $this->clearCache();
     }
 
     /**
@@ -64,5 +69,16 @@ class AlbumObserver
     public function forceDeleted(Album $album)
     {
         //
+    }
+
+    protected function clearCache(): void
+    {
+        try {
+            $cacheService = app(CacheService::class);
+            $prefix = config('theme-api.album.cache_prefix', 'album:api');
+            $cacheService->removeCachePrefix($prefix);
+        } catch (\Exception $e) {
+            //
+        }
     }
 }

--- a/app/Observers/GaleriObserver.php
+++ b/app/Observers/GaleriObserver.php
@@ -3,6 +3,7 @@
 namespace App\Observers;
 
 use App\Models\Galeri;
+use App\Services\CacheService;
 use Illuminate\Support\Facades\Storage;
 
 class GaleriObserver
@@ -15,7 +16,7 @@ class GaleriObserver
      */
     public function created(Galeri $galeri)
     {
-        //
+        $this->clearCache();
     }
 
     /**
@@ -41,6 +42,8 @@ class GaleriObserver
                 }
             }
         }
+
+        $this->clearCache();
     }
 
     /**
@@ -63,6 +66,8 @@ class GaleriObserver
                 }
             }
         }
+
+        $this->clearCache();
     }
 
     /**
@@ -85,5 +90,16 @@ class GaleriObserver
     public function forceDeleted(Galeri $galeri)
     {
         //
+    }
+
+    protected function clearCache(): void
+    {
+        try {
+            $cacheService = app(CacheService::class);
+            $prefix = config('theme-api.galeri.cache_prefix', 'galeri:api');
+            $cacheService->removeCachePrefix($prefix);
+        } catch (\Exception $e) {
+            //
+        }
     }
 }

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -1,4 +1,4 @@
-Di rilis versi v2606.0.1 di versi ini terdapat modul komentar pada artikel dan perbaikan lain yang diminta Komunitas.
+Di rilis versi v2607.0.0 di versi ini terdapat modul komentar pada artikel dan perbaikan lain yang diminta Komunitas.
 
 Terimakasih [isi disini] yang telah berkontribusi langsung mengembangkan aplikasi OpenDK.
 
@@ -12,7 +12,8 @@ Terimakasih [isi disini] yang telah berkontribusi langsung mengembangkan aplikas
 2. [#1574](https://github.com/OpenSID/OpenDK/issues/1574) Perbaikan Tidak ada tombol tambah dan tombol kelola data pada kolom aksi menu dokumen
 3. [#1577](https://github.com/OpenSID/OpenDK/issues/1577) Perbaikan Error csp di halaman /berita-desa
 4. [#1600](https://github.com/OpenSID/OpenDK/issues/1600) Perbaikan temuan pasca test manual
-4. [#1601](https://github.com/OpenSID/OpenDK/issues/1601) Perbaikan Filter Kode Kecamatan pada Semua Halaman DataTable Gabungan
+5. [#1601](https://github.com/OpenSID/OpenDK/issues/1601) Perbaikan Filter Kode Kecamatan pada Semua Halaman DataTable Gabungan
+6. [#1605](https://github.com/OpenSID/OpenDK/issues/1605) Perbaikan Data dokumen yang ditambahkan/dihapus tidak tampil sesuai di halaman web
 
 #### TEKNIS
 

--- a/config/theme-api.php
+++ b/config/theme-api.php
@@ -70,6 +70,15 @@ return [
         'default_order' => 'asc',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Form Dokumen API Settings
+    |--------------------------------------------------------------------------
+    */
+    'form_dokumen' => [
+        'cache_prefix' => env('FORM_DOKUMEN_API_CACHE_PREFIX', 'form_dokumen:api'),
+    ],
+
     'desa' => [
         'default_per_page' => env('DESA_API_DEFAULT_PER_PAGE', 15),
         'max_per_page' => env('DESA_API_MAX_PER_PAGE', 100),
@@ -93,6 +102,42 @@ return [
         ],
         'default_sort' => 'created_at',
         'default_order' => 'desc',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Album API Settings
+    |--------------------------------------------------------------------------
+    */
+    'album' => [
+        'cache_prefix' => env('ALBUM_API_CACHE_PREFIX', 'album:api'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Potensi API Settings
+    |--------------------------------------------------------------------------
+    */
+    'potensi' => [
+        'cache_prefix' => env('POTENSI_API_CACHE_PREFIX', 'potensi:api'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Regulasi API Settings
+    |--------------------------------------------------------------------------
+    */
+    'regulasi' => [
+        'cache_prefix' => env('REGULASI_API_CACHE_PREFIX', 'regulasi:api'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Komplain API Settings
+    |--------------------------------------------------------------------------
+    */
+    'komplain' => [
+        'cache_prefix' => env('KOMPLAIN_API_CACHE_PREFIX', 'komplain:api'),
     ],
 
     /*

--- a/tests/Unit/Listeners/ClearFormDokumenCacheListenerTest.php
+++ b/tests/Unit/Listeners/ClearFormDokumenCacheListenerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Events\FormDokumenChanged;
+use App\Listeners\ClearFormDokumenCacheListener;
+use App\Models\FormDokumen;
+use App\Services\CacheService;
+
+it('clears form dokumen cache when event is dispatched', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('form_dokumen:api')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearFormDokumenCacheListener();
+    $event = new FormDokumenChanged(new FormDokumen());
+
+    $listener->handle($event);
+});
+
+it('reads correct cache prefix from config', function () {
+    config(['theme-api.form_dokumen.cache_prefix' => 'custom:prefix']);
+
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('custom:prefix')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearFormDokumenCacheListener();
+    $event = new FormDokumenChanged(new FormDokumen());
+
+    $listener->handle($event);
+});
+
+it('handles exception gracefully', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->andThrow(new \Exception('Cache error'));
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    \Illuminate\Support\Facades\Log::shouldReceive('error')->once();
+
+    $listener = new ClearFormDokumenCacheListener();
+    $event = new FormDokumenChanged(new FormDokumen());
+
+    // Should not throw exception
+    $listener->handle($event);
+});

--- a/tests/Unit/Listeners/ClearPotensiCacheListenerTest.php
+++ b/tests/Unit/Listeners/ClearPotensiCacheListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Events\PotensiChanged;
+use App\Listeners\ClearPotensiCacheListener;
+use App\Models\Potensi;
+use App\Services\CacheService;
+
+it('clears potensi cache when event is dispatched', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('potensi:api')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearPotensiCacheListener();
+    $event = new PotensiChanged(new Potensi());
+
+    $listener->handle($event);
+});
+
+it('reads correct cache prefix from config', function () {
+    config(['theme-api.potensi.cache_prefix' => 'custom:potensi']);
+
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('custom:potensi')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearPotensiCacheListener();
+    $event = new PotensiChanged(new Potensi());
+
+    $listener->handle($event);
+});
+
+it('handles exception gracefully', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->andThrow(new \Exception('Cache error'));
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    \Illuminate\Support\Facades\Log::shouldReceive('error')->once();
+
+    $listener = new ClearPotensiCacheListener();
+    $event = new PotensiChanged(new Potensi());
+
+    $listener->handle($event);
+});

--- a/tests/Unit/Listeners/ClearRegulasiCacheListenerTest.php
+++ b/tests/Unit/Listeners/ClearRegulasiCacheListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Events\RegulasiChanged;
+use App\Listeners\ClearRegulasiCacheListener;
+use App\Models\Regulasi;
+use App\Services\CacheService;
+
+it('clears regulasi cache when event is dispatched', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('regulasi:api')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearRegulasiCacheListener();
+    $event = new RegulasiChanged(new Regulasi());
+
+    $listener->handle($event);
+});
+
+it('reads correct cache prefix from config', function () {
+    config(['theme-api.regulasi.cache_prefix' => 'custom:regulasi']);
+
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('custom:regulasi')
+        ->andReturnTrue();
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    $listener = new ClearRegulasiCacheListener();
+    $event = new RegulasiChanged(new Regulasi());
+
+    $listener->handle($event);
+});
+
+it('handles exception gracefully', function () {
+    $cacheService = Mockery::mock(CacheService::class);
+    $cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->andThrow(new \Exception('Cache error'));
+
+    $this->app->instance(CacheService::class, $cacheService);
+
+    \Illuminate\Support\Facades\Log::shouldReceive('error')->once();
+
+    $listener = new ClearRegulasiCacheListener();
+    $event = new RegulasiChanged(new Regulasi());
+
+    $listener->handle($event);
+});

--- a/tests/Unit/Observers/AlbumObserverTest.php
+++ b/tests/Unit/Observers/AlbumObserverTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Album;
+use App\Services\CacheService;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('public');
+    $this->cacheService = Mockery::mock(CacheService::class);
+    $this->app->instance(CacheService::class, $this->cacheService);
+});
+
+it('clears cache when album is created', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('album:api')
+        ->andReturnTrue();
+
+    Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+});
+
+it('clears cache when album is updated', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->with('album:api')
+        ->andReturnTrue()
+        ->twice();
+
+    $album = Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+
+    $album->update(['judul' => 'Updated Album']);
+});
+
+it('clears cache when album is deleted', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->with('album:api')
+        ->andReturnTrue()
+        ->twice();
+
+    $album = Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+
+    $album->delete();
+});

--- a/tests/Unit/Observers/GaleriObserverTest.php
+++ b/tests/Unit/Observers/GaleriObserverTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\Galeri;
+use App\Models\Album;
+use App\Services\CacheService;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('public');
+    $this->cacheService = Mockery::mock(CacheService::class);
+    $this->app->instance(CacheService::class, $this->cacheService);
+});
+
+it('clears cache when galeri is created', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->once()
+        ->with('galeri:api')
+        ->andReturnTrue();
+
+    $album = Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+
+    Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Test Galeri',
+        'gambar' => ['test.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+        'slug' => 'test-galeri',
+    ]);
+});
+
+it('clears cache when galeri is updated', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->with('galeri:api')
+        ->andReturnTrue()
+        ->twice();
+
+    $album = Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Test Galeri',
+        'gambar' => ['test.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+        'slug' => 'test-galeri',
+    ]);
+
+    $galeri->update(['judul' => 'Updated Galeri']);
+});
+
+it('clears cache when galeri is deleted', function () {
+    $this->cacheService->shouldReceive('removeCachePrefix')
+        ->with('galeri:api')
+        ->andReturnTrue()
+        ->twice();
+
+    $album = Album::create([
+        'judul' => 'Test Album',
+        'gambar' => 'test.jpg',
+        'status' => true,
+    ]);
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Test Galeri',
+        'gambar' => ['test.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+        'slug' => 'test-galeri',
+    ]);
+
+    $galeri->delete();
+});

--- a/themes/opendk/default/resources/views/pages/faq/index.blade.php
+++ b/themes/opendk/default/resources/views/pages/faq/index.blade.php
@@ -30,6 +30,7 @@
                 serverSide: false,
                 ajax: {
                     url: '{!! $urlApi ?? url("/api/frontend/v1") !!}/faq',
+                    cache: false,
                     dataSrc: 'data',
                     data: function(d) {
                         // Convert DataTables parameters to API format (use safe defaults to avoid NaN)

--- a/themes/opendk/default/resources/views/pages/unduhan/form-dokumen.blade.php
+++ b/themes/opendk/default/resources/views/pages/unduhan/form-dokumen.blade.php
@@ -34,6 +34,7 @@
                 serverSide: false,
                 ajax: {
                     url: '{!! $urlApi !!}/form-dokumen',
+                    cache: false,
                     dataSrc: 'data',
                     data: function(d) {                        
                         // Convert DataTables parameters to API format (use safe defaults to avoid NaN)

--- a/themes/opendk/default/resources/views/pages/unduhan/prosedur.blade.php
+++ b/themes/opendk/default/resources/views/pages/unduhan/prosedur.blade.php
@@ -36,6 +36,7 @@
                 serverSide: false,
                 ajax: {
                     url: '{!! $urlApi !!}/potensi',
+                    cache: false,
                     dataSrc: 'data',
                     data: function(d) {
                         // Convert DataTables parameters to API format (use safe defaults to avoid NaN)

--- a/themes/opendk/default/resources/views/pages/unduhan/regulasi.blade.php
+++ b/themes/opendk/default/resources/views/pages/unduhan/regulasi.blade.php
@@ -33,6 +33,7 @@
                 serverSide: false,
                 ajax: {
                     url: '{!! $urlApi !!}/regulasi',
+                    cache: false,
                     dataSrc: 'data',
                     data: function(d) {
                         // Convert DataTables parameters to API format (use safe defaults to avoid NaN)


### PR DESCRIPTION
# Pull Request: Fix cache invalidation pada halaman website frontend

## Description

Data dokumen, galeri, album, potensi, dan regulasi yang ditambahkan/dihapus/diperbarui melalui admin panel tidak langsung tampil terbaru di halaman website. API frontend menggunakan `Cache::remember` tanpa mekanisme invalidation otomatis, sehingga admin harus manual clear cache setiap ada perubahan data.

Solusi: implementasikan Event-Listener pattern pada model untuk auto-clear cache saat data berubah, migrasi API controllers ke `CacheService::remember()` agar cache keys ter-track di database, dan tambahkan `cache: false` pada DataTables AJAX config untuk mencegah browser caching.

### Changes made:

1. **[New File]**: `app/Events/FormDokumenChanged.php` - Event class untuk form dokumen cache invalidation
2. **[New File]**: `app/Events/PotensiChanged.php` - Event class untuk potensi cache invalidation
3. **[New File]**: `app/Events/RegulasiChanged.php` - Event class untuk regulasi cache invalidation
4. **[New File]**: `app/Listeners/ClearFormDokumenCacheListener.php` - Listener yang clear cache prefix `form_dokumen:api`
5. **[New File]**: `app/Listeners/ClearPotensiCacheListener.php` - Listener yang clear cache prefix `potensi:api`
6. **[New File]**: `app/Listeners/ClearRegulasiCacheListener.php` - Listener yang clear cache prefix `regulasi:api`
7. **[Modified]**: `app/Models/FormDokumen.php` - Tambah `booted()` method untuk dispatch event pada created/updated/deleted
8. **[Modified]**: `app/Models/Potensi.php` - Sama seperti FormDokumen
9. **[Modified]**: `app/Models/Regulasi.php` - Sama seperti FormDokumen
10. **[Modified]**: `app/Observers/GaleriObserver.php` - Tambah `clearCache()` method yang dipanggil di created/updated/deleted
11. **[Modified]**: `app/Observers/AlbumObserver.php` - Sama seperti GaleriObserver
12. **[Modified]**: `app/Http/Controllers/Api/Frontend/FormDokumenController.php` - `Cache::remember()` → `$this->cacheService->remember()` dengan prefix tracking
13. **[Modified]**: `app/Http/Controllers/Api/Frontend/GaleriController.php` - Sama seperti FormDokumenController
14. **[Modified]**: `app/Http/Controllers/Api/Frontend/AlbumController.php` - Sama seperti FormDokumenController
15. **[Modified]**: `app/Http/Controllers/Api/Frontend/PotensiController.php` - Sama seperti FormDokumenController
16. **[Modified]**: `app/Http/Controllers/Api/Frontend/RegulasiController.php` - Sama seperti FormDokumenController
17. **[Modified]**: `config/theme-api.php` - Tambah cache_prefix config untuk form_dokumen, album, potensi, regulasi, komplain
18. **[Modified]**: `themes/.../form-dokumen.blade.php` - Tambah `cache: false` pada DataTables AJAX
19. **[Modified]**: `themes/.../prosedur.blade.php` - Sama seperti form-dokumen
20. **[Modified]**: `themes/.../regulasi.blade.php` - Sama seperti form-dokumen
21. **[Modified]**: `themes/.../faq/index.blade.php` - Sama seperti form-dokumen
22. **[New File]**: `tests/Unit/Listeners/ClearFormDokumenCacheListenerTest.php` - Unit test untuk listener
23. **[New File]**: `tests/Unit/Listeners/ClearPotensiCacheListenerTest.php` - Unit test untuk listener
24. **[New File]**: `tests/Unit/Listeners/ClearRegulasiCacheListenerTest.php` - Unit test untuk listener
25. **[New File]**: `tests/Unit/Observers/GaleriObserverTest.php` - Unit test untuk observer
26. **[New File]**: `tests/Unit/Observers/AlbumObserverTest.php` - Unit test untuk observer

### Reason for change:

- **Bug**: API frontend menggunakan `Cache::remember()` tanpa mekanisme invalidation. Saat admin menambah/menghapus data, cache lama masih tersimpan dan website menampilkan data usang.
- **Root Cause**: Controller API menggunakan `Cache::remember()` langsung, yang tidak ter-track di database `cache_keys`. Ketika `CacheService::removeCachePrefix()` dipanggil, tidak ada cache keys yang ditemukan karena tidak pernah di-register.
- **Browser Caching**: DataTables AJAX tanpa `cache: false` menyebabkan browser menyimpan response AJAX lama, bahkan setelah server-side cache di-clear.

### Impact of change:

- ✅ **Auto-invalidation**: Cache otomatis clear saat model FormDokumen, Potensi, Regulasi, Galeri, atau Album di-create/update/delete
- ✅ **Cache tracking**: Semua cache keys ter-track di database `cache_keys` melalui `CacheService::remember()`, memungkinkan precise invalidation
- ✅ **Browser freshness**: `cache: false` pada DataTables AJAX mencegah browser menyimpan response lama
- ✅ **Consistency**: Semua API frontend controllers menggunakan pola cache yang sama (`CacheService::remember()` + prefix tracking)
- ✅ **No manual intervention**: Admin tidak perlu lagi manual clear cache setiap ada perubahan data

## Related Issue

Issue #1605 

## Steps to Reproduce

### Before fix (problem):

1. Login ke admin panel
2. Buka menu Unduhan > Form Dokumen
3. Tambah data dokumen baru
4. Buka halaman website `/unduhan/form-dokumen`
5. ❌ Data dokumen baru tidak tampil (masih data lama dari cache)
6. Harus manual clear cache agar data baru muncul

### After fix (solution):

1. Login ke admin panel
2. Buka menu Unduhan > Form Dokumen
3. Tambah data dokumen baru
4. Buka halaman website `/unduhan/form-dokumen`
5. ✅ Data dokumen baru langsung tampil tanpa perlu clear cache manual

### Testing on related features:
- Form Dokumen ✅ Cache clear otomatis saat CRUD
- Galeri ✅ Cache clear otomatis saat CRUD (via Observer)
- Album ✅ Cache clear otomatis saat CRUD (via Observer)
- Potensi ✅ Cache clear otomatis saat CRUD
- Regulasi ✅ Cache clear otomatis saat CRUD
- FAQ ✅ Browser cache disabled via `cache: false`

## Checklist

- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] I have created unit tests to verify the fix (15 tests, all passing)
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings
- [ ] Code has been reviewed by at least 1 person

## Technical Details

### Technical Explanation

**Event-Listener Pattern (untuk model tanpa Observer):**

```php
// Model: booted() method
protected static function booted(): void
{
    static::created(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
    static::updated(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
    static::deleted(fn (FormDokumen $dokumen) => FormDokumenChanged::dispatch($dokumen));
}

// Listener: handle() method
public function handle(FormDokumenChanged $event)
{
    $cacheService = app(CacheService::class);
    $prefix = config('theme-api.form_dokumen.cache_prefix', 'form_dokumen:api');
    $cacheService->removeCachePrefix($prefix);
}
```

**Observer Modification (untuk model yang sudah punya Observer):**

```php
// GaleriObserver/AlbumObserver: tambah clearCache() di created/updated/deleted
protected function clearCache(): void
{
    $cacheService = app(CacheService::class);
    $prefix = config('theme-api.galeri.cache_prefix', 'galeri:api');
    $cacheService->removeCachePrefix($prefix);
}
```

**CacheService Flow:**

```
API Request → CacheService::remember() → Cache::has()? 
  → YES: return cached value
  → NO: execute callback → Cache::put() → storeCacheKey() (save to DB) → return value

Model Change → Event Dispatched → Listener → CacheService::removeCachePrefix()
  → Query cache_keys WHERE prefix LIKE '%{prefix}%'
  → Cache::forget() for each key
  → Delete records from cache_keys table
```

### Configuration changes

Added to `config/theme-api.php`:

```php
'form_dokumen' => [
    'cache_prefix' => env('FORM_DOKUMEN_API_CACHE_PREFIX', 'form_dokumen:api'),
],
'album' => [
    'cache_prefix' => env('ALBUM_API_CACHE_PREFIX', 'album:api'),
],
'potensi' => [
    'cache_prefix' => env('POTENSI_API_CACHE_PREFIX', 'potensi:api'),
],
'regulasi' => [
    'cache_prefix' => env('REGULASI_API_CACHE_PREFIX', 'regulasi:api'),
],
'komplain' => [
    'cache_prefix' => env('KOMPLAIN_API_CACHE_PREFIX', 'komplain:api'),
],
```

### Dependencies added

No new dependencies added.

## Video

https://github.com/user-attachments/assets/ca0303a5-d6f1-4b8c-b9cf-ad76d3962285


### Manual Testing
pastikan sudah lakukan perintah `php artisan cache:clear` agar cache lama terhapus terlebih dahulu

- [ ] Tambah data Form Dokumen di admin → cek website langsung tampil
- [ ] Edit data Form Dokumen di admin → cek website langsung update
- [ ] Hapus data Form Dokumen di admin → cek website langsung hapus
- [ ] Ulangi test untuk Galeri, Album, Potensi, Regulasi
- [ ] Buka halaman website, lalu edit data di admin, refresh browser → data terbaru muncul
- [ ] Cek Developer Tools Network tab → AJAX request tidak ter-cache (ada parameter `_={timestamp}`)
- [ ] Regression testing: pastikan fitur existing tidak terganggu

### Automated Testing

- [x] `tests/Unit/Listeners/ClearFormDokumenCacheListenerTest.php` - 3 tests
- [x] `tests/Unit/Listeners/ClearPotensiCacheListenerTest.php` - 3 tests
- [x] `tests/Unit/Listeners/ClearRegulasiCacheListenerTest.php` - 3 tests
- [x] `tests/Unit/Observers/GaleriObserverTest.php` - 3 tests
- [x] `tests/Unit/Observers/AlbumObserverTest.php` - 3 tests

## Breaking Changes

None

## Migration Guide

Not required

## References

- [Laravel Cache Documentation](https://laravel.com/docs/11.x/cache)
- [Laravel Events Documentation](https://laravel.com/docs/11.x/events)
- [DataTables AJAX Cache](https://datatables.net/reference/option/ajax.cache)

---

**Additional notes:**

- Seluruh 15 unit tests berhasil passing
- Event-Listener digunakan untuk FormDokumen, Potensi, Regulasi (model baru tanpa Observer)
- Observer dimodifikasi untuk Galeri, Album (model sudah punya Observer untuk file cleanup)
- `cache: false` ditambahkan ke 4 halaman blade yang menggunakan DataTables AJAX ke API frontend
- Cache driver menggunakan file (default), cache keys di-track di database `cache_keys` table
