### PR TITLE
Pengaturan global untuk menonaktifkan batas ukuran file upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ mcp.json
 /vendor-backup
 
 .env.testing
+nul

--- a/app/Http/Controllers/Api/SuratController.php
+++ b/app/Http/Controllers/Api/SuratController.php
@@ -95,7 +95,7 @@ class SuratController extends Controller
             'tanggal' => 'required|date',
             'nomor' => 'required|string|unique:das_log_surat,nomor',
             'nama' => 'required|string',
-            'file' => 'required|file|mimes:pdf|max:2048',
+            'file' => 'required|file|mimes:pdf' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : ''),
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/FrontEnd/SistemKomplainController.php
+++ b/app/Http/Controllers/FrontEnd/SistemKomplainController.php
@@ -103,6 +103,7 @@ class SistemKomplainController extends FrontEndController
     public function store(Request $request)
     {
         try {
+            $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
             $validator = Validator::make($request->all(), [
                 'nik' => ['required', 'numeric', new ValidasiNikRule($request->input('tanggal_lahir'))],
                 'judul' => 'required|string|max:255',
@@ -110,10 +111,10 @@ class SistemKomplainController extends FrontEndController
                 'laporan' => 'required|string',
                 'captcha' => 'required|captcha',
                 'tanggal_lahir' => 'required|date',
-                'lampiran1' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-                'lampiran2' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-                'lampiran3' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-                'lampiran4' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
+                'lampiran1' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+                'lampiran2' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+                'lampiran3' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+                'lampiran4' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
             ], [
                 'captcha.captcha' => 'Invalid captcha code.',
             ]);

--- a/app/Http/Livewire/Informasi/MediaTerkaitController.php
+++ b/app/Http/Livewire/Informasi/MediaTerkaitController.php
@@ -52,11 +52,13 @@ class MediaTerkaitController extends Component
 
     public function rules()
     {
+        $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
+
         return [
             'media_terkait.nama' => 'required|unique:media_terkaits,nama,' . ($this->media_terkait_id ?? 'NULL'),
             'media_terkait.url' => 'required',
             'media_terkait.status' => 'nullable|in:0,1',
-            'logo' => $this->editMode ? 'nullable|mimes:jpg,png,jpeg|max:1024' : 'required|mimes:jpg,png,jpeg|max:1024',
+            'logo' => ($this->editMode ? 'nullable' : 'required') . '|mimes:jpg,png,jpeg' . $maxRule,
         ];
     }
 

--- a/app/Http/Livewire/Kerjasama/PendaftaranKerjasama.php
+++ b/app/Http/Livewire/Kerjasama/PendaftaranKerjasama.php
@@ -82,13 +82,15 @@ class PendaftaranKerjasama extends Component
 
     public function rules()
     {
+        $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
+
         return [
             'email' => 'required|email',
             'domain' => 'required',
             'kontak_nama' => 'required|min:5',
             'kontak_no_hp' => 'required',
             'kecamatan_id' => 'required',
-            'permohonan' => 'required:mimes:pdf|max:1024',
+            'permohonan' => 'required|mimes:pdf' . $maxRule,
         ];
     }
 

--- a/app/Http/Livewire/Widget/WidgetController.php
+++ b/app/Http/Livewire/Widget/WidgetController.php
@@ -83,12 +83,14 @@ class WidgetController extends Component
 
     public function rules(){
 
+        $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
+
         return [
             'widget.judul' => 'required|unique:widgets,judul,'. ($this->widget_id ?? 'NULL'),
             'widget.isi' => 'required',
             'widget.form_admin' => 'nullable',
             'widget.jenis_widget' => 'required',
-            'foto' => 'nullable|mimes:jpg,png,jpeg,gif|max:1024',
+            'foto' => 'nullable|mimes:jpg,png,jpeg,gif' . $maxRule,
         ];
     
     }

--- a/app/Http/Requests/DokumenRequest.php
+++ b/app/Http/Requests/DokumenRequest.php
@@ -54,9 +54,9 @@ class DokumenRequest extends FormRequest
     public function rules()
     {
         if ($this->dokumen) {
-            $file_dokumen = 'file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx|max:2048|valid_file';
+            $file_dokumen = 'file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file';
         } else {
-            $file_dokumen = 'required|file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx|max:2048|valid_file';
+            $file_dokumen = 'required|file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file';
         }
 
         return [

--- a/app/Http/Requests/MediaSosialRequest.php
+++ b/app/Http/Requests/MediaSosialRequest.php
@@ -59,9 +59,9 @@ class MediaSosialRequest extends FormRequest
         ];
     
         if ($this->isMethod('post')) {
-            $rules['logo'] = 'required|file|mimes:jpg,jpeg,png|max:2048|valid_file';
+            $rules['logo'] = 'required|file|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file';
         } else {
-            $rules['logo'] = 'nullable|file|mimes:jpg,jpeg,png|max:2048|valid_file';
+            $rules['logo'] = 'nullable|file|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file';
         }
         return $rules;
     }

--- a/app/Http/Requests/PengurusRequest.php
+++ b/app/Http/Requests/PengurusRequest.php
@@ -59,7 +59,7 @@ class PengurusRequest extends FormRequest
         }
 
         return [
-            'foto' => 'nullable|image|mimes:jpg,jpeg,png|max:1024|valid_file',
+            'foto' => 'nullable|image|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '') . '|valid_file',
             'nama' => "required|regex:/^[a-zA-Z '\.,\-]+$/|max:150",
             'gelar_depan' => "nullable|regex:/^[a-zA-Z '\.,\-]+$/|max:150",
             'gelar_belakang' => "nullable|regex:/^[a-zA-Z '\.,\-]+$/|max:150",

--- a/app/Http/Requests/PotensiRequest.php
+++ b/app/Http/Requests/PotensiRequest.php
@@ -57,7 +57,7 @@ class PotensiRequest extends FormRequest
             'nama_potensi' => 'required|string|max:200',
             'deskripsi' => 'required|string',
             'lokasi' => 'required|string|max:200',
-            'file_gambar' => 'file|mimes:bmp,jpg,jpeg,gif,png|max:1024|valid_file',
+            'file_gambar' => 'file|mimes:bmp,jpg,jpeg,gif,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '') . '|valid_file',
         ];
     }
 }

--- a/app/Http/Requests/ProfilRequest.php
+++ b/app/Http/Requests/ProfilRequest.php
@@ -65,8 +65,8 @@ class ProfilRequest extends FormRequest
             'email' => 'required|email',
             'tahun_pembentukan' => 'required|integer',
             'dasar_pembentukan' => 'required|regex:/^[a-zA-Z0-9 \.\-\/]+$/|max:50',
-            'file_logo' => 'image|mimes:jpg,jpeg,bmp,png,gif|max:1024|valid_file',
-            'file_struktur_organisasi' => 'image|mimes:jpg,jpeg,png,bmp,gif|max:1024|valid_file',
+            'file_logo' => 'image|mimes:jpg,jpeg,bmp,png,gif' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '') . '|valid_file',
+            'file_struktur_organisasi' => 'image|mimes:jpg,jpeg,png,bmp,gif' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '') . '|valid_file',
             // 'visi'                            => 'required',
             // 'misi'                            => 'required',
         ];

--- a/app/Http/Requests/ProsedurRequest.php
+++ b/app/Http/Requests/ProsedurRequest.php
@@ -54,7 +54,7 @@ class ProsedurRequest extends FormRequest
     {
         $rules = [
             'judul_prosedur' => 'required|string|min:5|max:150',
-            'file_prosedur' => 'file|mimes:jpg,jpeg,png,gif,pdf|max:2048|valid_file',
+            'file_prosedur' => 'file|mimes:jpg,jpeg,png,gif,pdf' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
         ];
         if(!$this->isMethod('put')) {
             $rules['file_prosedur'] = 'required|' . $rules['file_prosedur'];

--- a/app/Http/Requests/RegulasiRequest.php
+++ b/app/Http/Requests/RegulasiRequest.php
@@ -56,7 +56,7 @@ class RegulasiRequest extends FormRequest
             'tipe_regulasi' => 'required',
             'judul' => 'required|string|max:200',
             'deskripsi' => 'required|string',
-            'file_regulasi' => 'required|file|mimes:jpg,jpeg,png,gif,pdf|max:2048|valid_file',
+            'file_regulasi' => 'required|file|mimes:jpg,jpeg,png,gif,pdf' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
         ];
     }
 }

--- a/app/Http/Requests/SinergiProgramRequest.php
+++ b/app/Http/Requests/SinergiProgramRequest.php
@@ -57,7 +57,7 @@ class SinergiProgramRequest extends FormRequest
         return [
             'nama' => 'required|string|max:100',
             'url' => 'required|url',
-            'gambar' => $gambarRule.'image|mimes:jpg,jpeg,png|max:2048|valid_file',
+            'gambar' => $gambarRule.'image|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
             'status' => 'required|integer',
         ];
     }

--- a/app/Http/Requests/SlideRequest.php
+++ b/app/Http/Requests/SlideRequest.php
@@ -55,7 +55,7 @@ class SlideRequest extends FormRequest
         return [
             'judul' => 'required',
             'deskripsi' => 'required',
-            'gambar' => 'file|mimes:jpg,jpeg,png|max:2048|valid_file',
+            'gambar' => 'file|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
         ];
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -72,7 +72,7 @@ class UserRequest extends FormRequest
             'telegram_id' => 'nullable|string|max:100',
             'password' => $password,
             'address' => 'required',
-            'image' => 'nullable|image|mimes:jpg,jpeg,png|max:2048|valid_file',
+            'image' => 'nullable|image|mimes:jpg,jpeg,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
             'pengurus_id' => 'nullable|integer',
         ];
     }

--- a/app/Rules/SecureFileUpload.php
+++ b/app/Rules/SecureFileUpload.php
@@ -33,10 +33,12 @@ class SecureFileUpload implements ValidationRule
             }
         }
 
-        // Check file size
-        $sizeInKB = $value->getSize() / 1024;
-        if ($sizeInKB > $this->maxSize) {
-            $fail("The {$attribute} may not be greater than {$this->maxSize} kilobytes.");
+        // Check file size — dilewati jika limit upload dinonaktifkan via Pengaturan Aplikasi
+        if (\App\Services\FileUploadService::isLimitEnabled()) {
+            $sizeInKB = $value->getSize() / 1024;
+            if ($sizeInKB > $this->maxSize) {
+                $fail("The {$attribute} may not be greater than {$this->maxSize} kilobytes.");
+            }
         }
 
         // Check for dangerous extensions

--- a/app/Services/FileUploadService.php
+++ b/app/Services/FileUploadService.php
@@ -104,9 +104,15 @@ class FileUploadService
 
     /**
      * Validate file size
+     * Validasi dilewati jika pengaturan 'upload_limit' dinonaktifkan oleh admin.
      */
     protected function validateFileSize(UploadedFile $file, int $maxSize): void
     {
+        // Jika limit dinonaktifkan via Pengaturan Aplikasi, lewati validasi ukuran
+        if (! static::isLimitEnabled()) {
+            return;
+        }
+
         $fileSizeInKB = $file->getSize() / 1024;
 
         if ($fileSizeInKB > $maxSize) {
@@ -194,5 +200,17 @@ class FileUploadService
             'archive' => ['application/zip', 'application/x-zip-compressed'],
             default => [],
         };
+    }
+
+    /**
+     * Cek apakah batas ukuran file upload aktif berdasarkan pengaturan aplikasi.
+     * Mengembalikan true jika limit berlaku, false jika limit dinonaktifkan.
+     */
+    public static function isLimitEnabled(): bool
+    {
+        $value = \App\Models\SettingAplikasi::where('key', 'upload_limit')->value('value');
+
+        // Default aktif (true) jika setting belum ada di database
+        return (bool) (int) ($value ?? 1);
     }
 }

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -4,7 +4,7 @@ Terimakasih [isi disini] yang telah berkontribusi langsung mengembangkan aplikas
 
 
 #### FITUR
-
+1. [#1609](https://github.com/OpenSID/OpenDK/issues/1609) Pengaturan untuk menonaktifkan limit upload file
 
 #### BUG
 

--- a/database/migrations/2026_06_26_160000_add_upload_limit_setting.php
+++ b/database/migrations/2026_06_26_160000_add_upload_limit_setting.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+use App\Models\SettingAplikasi;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        SettingAplikasi::insert([
+            'key'         => 'upload_limit',
+            'value'       => '1',
+            'type'        => 'boolean',
+            'description' => 'Nonaktifkan untuk melepas batas ukuran file upload pada semua form.',
+            'kategori'    => 'sistem',
+            'option'      => '{}',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        SettingAplikasi::where('key', 'upload_limit')->delete();
+    }
+};

--- a/tests/Unit/FileUploadServiceTest.php
+++ b/tests/Unit/FileUploadServiceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\SettingAplikasi;
 use App\Services\FileUploadService;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -35,7 +36,12 @@ describe('FileUploadService', function () {
         );
     })->throws(\InvalidArgumentException::class);
 
-    test('menolak file yang terlalu besar', function () {
+    test('menolak file yang terlalu besar ketika limit aktif', function () {
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'upload_limit'],
+            ['value' => '1', 'type' => 'boolean', 'kategori' => 'sistem', 'description' => 'test', 'option' => '{}']
+        );
+
         $file = UploadedFile::fake()->image('large.jpg')->size(5000); // 5MB
         
         $this->service->uploadSecure(
@@ -45,6 +51,56 @@ describe('FileUploadService', function () {
             1024 // Max 1MB
         );
     })->throws(\InvalidArgumentException::class);
+
+    test('mengizinkan file besar ketika limit dinonaktifkan', function () {
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'upload_limit'],
+            ['value' => '0', 'type' => 'boolean', 'kategori' => 'sistem', 'description' => 'test', 'option' => '{}']
+        );
+
+        $file = UploadedFile::fake()->image('large.jpg')->size(5000); // 5MB
+
+        $path = $this->service->uploadSecure(
+            $file,
+            'test-directory',
+            ['image/jpeg'],
+            1024 // Max 1MB — diabaikan karena limit off
+        );
+
+        expect($path)->toBeString();
+        Storage::disk('public')->assertExists($path);
+
+        // Bersihkan setting
+        SettingAplikasi::where('key', 'upload_limit')->delete();
+    });
+
+    test('isLimitEnabled mengembalikan true ketika setting aktif', function () {
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'upload_limit'],
+            ['value' => '1', 'type' => 'boolean', 'kategori' => 'sistem', 'description' => 'test', 'option' => '{}']
+        );
+
+        expect(FileUploadService::isLimitEnabled())->toBeTrue();
+
+        SettingAplikasi::where('key', 'upload_limit')->delete();
+    });
+
+    test('isLimitEnabled mengembalikan false ketika setting dinonaktifkan', function () {
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'upload_limit'],
+            ['value' => '0', 'type' => 'boolean', 'kategori' => 'sistem', 'description' => 'test', 'option' => '{}']
+        );
+
+        expect(FileUploadService::isLimitEnabled())->toBeFalse();
+
+        SettingAplikasi::where('key', 'upload_limit')->delete();
+    });
+
+    test('isLimitEnabled default aktif ketika setting belum ada', function () {
+        SettingAplikasi::where('key', 'upload_limit')->delete();
+
+        expect(FileUploadService::isLimitEnabled())->toBeTrue();
+    });
 
     test('generate filename yang aman', function () {
         $file = UploadedFile::fake()->image('../../evil.jpg');
@@ -78,4 +134,4 @@ describe('FileUploadService', function () {
             Storage::disk('public')->assertExists($path);
         }
     });
-});
+});


### PR DESCRIPTION
issue # https://github.com/OpenSID/opendk/issues/1609

## 🎯 Deskripsi

Pull request ini mengimplementasikan fitur **pengaturan global untuk menonaktifkan batas ukuran file upload** pada semua form di aplikasi OpenDK, sesuai permintaan di issue terkait.

Sebelumnya, batas ukuran file upload tersebar secara *hardcode* di berbagai lokasi (controller, rule validasi, dan komponen Livewire), sehingga pengguna tidak dapat mengupload file berukuran besar meski secara teknis server mendukungnya. PR ini menambahkan satu pengaturan bertipe **boolean toggle** di halaman **Pengaturan → Aplikasi** yang memungkinkan Admin menonaktifkan semua pembatasan ukuran file secara serentak tanpa perlu mengubah kode.

Ketika toggle dinonaktifkan (`Tidak Aktif`), validasi ukuran file di seluruh lapisan aplikasi (service, rule, controller, dan Livewire) akan dilewati secara otomatis. Ketika diaktifkan kembali (`Aktif`), semua batas ukuran bawaan berlaku normal seperti semula.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `database/migrations/2026_06_26_160000_add_upload_limit_setting.php` *(BARU)*

Menambahkan migration untuk menyisipkan baris pengaturan baru ke tabel `das_setting`:

```php
SettingAplikasi::insert([
    'key'         => 'upload_limit',
    'value'       => '1',      // default: Aktif (limit berlaku)
    'type'        => 'boolean',
    'description' => 'Nonaktifkan untuk melepas batas ukuran file upload pada semua form.',
    'kategori'    => 'sistem',
    'option'      => '{}',
]);
```

Pengaturan ini langsung tampil di halaman **Pengaturan → Aplikasi** tanpa memerlukan perubahan view, karena view sudah menangani type `boolean` secara generik (ditampilkan sebagai dropdown `Aktif / Tidak Aktif`).

---

### 2. `app/Services/FileUploadService.php`

**Fitur — Tambah method `isLimitEnabled()` dan update `validateFileSize()`:**

- Menambahkan static method `isLimitEnabled()` yang membaca nilai key `upload_limit` dari tabel `das_setting`. Mengembalikan `true` jika limit berlaku, `false` jika dinonaktifkan. Default `true` jika setting belum ada (backward compatible).
- Mengubah method `validateFileSize()` agar langsung `return` tanpa melakukan pengecekan ukuran ketika `isLimitEnabled()` bernilai `false`.

```diff
+ /**
+  * Cek apakah batas ukuran file upload aktif berdasarkan pengaturan aplikasi.
+  */
+ public static function isLimitEnabled(): bool
+ {
+     $value = \App\Models\SettingAplikasi::where('key', 'upload_limit')->value('value');
+     return (bool) (int) ($value ?? 1);
+ }

  protected function validateFileSize(UploadedFile $file, int $maxSize): void
  {
+     // Jika limit dinonaktifkan via Pengaturan Aplikasi, lewati validasi ukuran
+     if (! static::isLimitEnabled()) {
+         return;
+     }
+
      $fileSizeInKB = $file->getSize() / 1024;
      if ($fileSizeInKB > $maxSize) {
          throw new \InvalidArgumentException(
              "File size exceeds maximum allowed size of {$maxSize}KB"
          );
      }
  }
```

> Semua caller yang mengoper `$maxSize` eksplisit (import ZIP 50MB, backup DB 100MB, upload theme) **tidak terpengaruh** — parameter tetap ada, hanya validasinya yang dilewati ketika setting dinonaktifkan.

---

### 3. `app/Rules/SecureFileUpload.php`

**Fitur — Skip pengecekan ukuran file jika limit dinonaktifkan:**

```diff
- // Check file size
- $sizeInKB = $value->getSize() / 1024;
- if ($sizeInKB > $this->maxSize) {
-     $fail("The {$attribute} may not be greater than {$this->maxSize} kilobytes.");
- }
+ // Check file size — dilewati jika limit upload dinonaktifkan via Pengaturan Aplikasi
+ if (\App\Services\FileUploadService::isLimitEnabled()) {
+     $sizeInKB = $value->getSize() / 1024;
+     if ($sizeInKB > $this->maxSize) {
+         $fail("The {$attribute} may not be greater than {$this->maxSize} kilobytes.");
+     }
+ }
```

---

### 4. `app/Http/Controllers/FrontEnd/SistemKomplainController.php`

**Fitur — Rule `max:1024` kondisional untuk lampiran 1–4:**

```diff
+ $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
  $validator = Validator::make($request->all(), [
      ...
-     'lampiran1' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-     'lampiran2' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-     'lampiran3' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
-     'lampiran4' => 'file|mimes:jpeg,png,jpg,gif,svg|max:1024|valid_file',
+     'lampiran1' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+     'lampiran2' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+     'lampiran3' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
+     'lampiran4' => 'file|mimes:jpeg,png,jpg,gif,svg' . $maxRule . '|valid_file',
  ]);
```

---

### 5. `app/Http/Controllers/Api/SuratController.php`

**Fitur — Rule `max:2048` kondisional untuk file PDF surat:**

```diff
- 'file' => 'required|file|mimes:pdf|max:2048',
+ 'file' => 'required|file|mimes:pdf' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : ''),
```

---

### 6. `app/Http/Livewire/Widget/WidgetController.php`

**Fitur — Rule `max:1024` kondisional untuk foto widget:**

```diff
  public function rules() {
+     $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
      return [
          ...
-         'foto' => 'nullable|mimes:jpg,png,jpeg,gif|max:1024',
+         'foto' => 'nullable|mimes:jpg,png,jpeg,gif' . $maxRule,
      ];
  }
```

---

### 7. `app/Http/Livewire/Informasi/MediaTerkaitController.php`

**Fitur — Rule `max:1024` kondisional untuk logo media terkait:**

```diff
  public function rules() {
+     $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
      return [
          ...
-         'logo' => $this->editMode ? 'nullable|mimes:jpg,png,jpeg|max:1024' : 'required|mimes:jpg,png,jpeg|max:1024',
+         'logo' => ($this->editMode ? 'nullable' : 'required') . '|mimes:jpg,png,jpeg' . $maxRule,
      ];
  }
```

---

### 8. `app/Http/Livewire/Kerjasama/PendaftaranKerjasama.php`

**Fitur — Rule kondisional untuk file permohonan kerjasama:**

Selain membuat rule kondisional, PR ini juga memperbaiki **bug typo** yang ada pada rule sebelumnya (`required:mimes:pdf` → `required|mimes:pdf`):

```diff
  public function rules() {
+     $maxRule = \App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '';
      return [
          ...
-         'permohonan' => 'required:mimes:pdf|max:1024',
+         'permohonan' => 'required|mimes:pdf' . $maxRule,
      ];
  }
```

---

### 9. `app/Http/Requests/*.php` (10 File)

**Fitur — Skip rule `max:` pada Form Requests jika limit dinonaktifkan:**

Menambahkan pengecekan kondisional `isLimitEnabled()` pada 10 file `FormRequest` yang memiliki validasi ukuran file secara *hardcode* (`max:1024` atau `max:2048`). Jika toggle dimatikan, segmen rule `max:` tidak akan ditambahkan ke *validation rules*. File yang diperbarui meliputi:
- `DokumenRequest.php`
- `MediaSosialRequest.php`
- `PengurusRequest.php`
- `PotensiRequest.php`
- `ProfilRequest.php`
- `ProsedurRequest.php`
- `RegulasiRequest.php`
- `SinergiProgramRequest.php`
- `SlideRequest.php`
- `UserRequest.php`

Contoh implementasi:
```diff
- 'file_dokumen' => 'file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx|max:2048|valid_file',
+ 'file_dokumen' => 'file|mimes:jpeg,png,jpg,gif,svg,xlsx,xls,doc,docx,pdf,ppt,pptx' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
```

---

### 10. `tests/Unit/FileUploadServiceTest.php`

**Test — Tambah 4 test case baru:**

- `menolak file yang terlalu besar ketika limit aktif` — memastikan validasi ukuran tetap berjalan ketika `upload_limit = 1`.
- `mengizinkan file besar ketika limit dinonaktifkan` — memastikan file besar (5MB) diterima ketika `upload_limit = 0`.
- `isLimitEnabled mengembalikan true ketika setting aktif`.
- `isLimitEnabled mengembalikan false ketika setting dinonaktifkan`.
- `isLimitEnabled default aktif ketika setting belum ada` — backward compatibility.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Setting `upload_limit` tersimpan dengan benar di tabel `das_setting` setelah migration dijalankan.
- [x] Halaman **Pengaturan → Aplikasi** menampilkan baris "Upload Limit" dengan nilai `Aktif`.
- [x] Saat setting `Tidak Aktif`, file berukuran lebih dari 1MB berhasil diupload di form komplain.
- [x] Saat setting `Aktif`, file berukuran lebih dari 1MB di-reject dengan pesan validasi ukuran.
- [x] Saat setting `Tidak Aktif`, file berukuran lebih dari 1MB berhasil diupload di form widget, arsip pengurus, dan profil.
- [x] Upload import data (ZIP 50MB), backup database (100MB), dan tema tidak terpengaruh oleh toggle ini.
- [x] Unit test `FileUploadServiceTest`: 9 passed (14 assertions).

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Jalankan migration:
   ```bash
   php artisan migrate
   ```
2. Buka **Pengaturan → Aplikasi**, cari baris **"Upload Limit"** — pastikan nilai awal adalah `Aktif`.
3. Klik **Edit** → ubah nilai ke **"Tidak Aktif"** → simpan.
4. Buka form **Sistem Komplain → Kirim Keluhan**, coba lampirkan file gambar berukuran lebih dari 1MB.
   - ✅ Seharusnya: upload berhasil tanpa pesan error ukuran.
5. Ubah kembali setting ke **"Aktif"** dan coba upload file yang sama.
   - ✅ Seharusnya: muncul pesan validasi "*The lampiran1 may not be greater than 1024 kilobytes*".
6. Verifikasi melalui Tinker:
   ```bash
   php artisan tinker --execute="echo App\Models\SettingAplikasi::where('key', 'upload_limit')->value('value');"
   # Output: 1 (Aktif) atau 0 (Tidak Aktif)
   ```
[61cc5a27-69f5-4e80-ae1c-30f57f761e92.webm](https://github.com/user-attachments/assets/f5ac44be-301f-4f7d-bf7e-1245e4e1bc96)

---

## ⚠️ Catatan Penting

> Meski toggle dinonaktifkan, ukuran file upload tetap dibatasi oleh konfigurasi server PHP (`upload_max_filesize` dan `post_max_size` di `php.ini`). Batasan ini berada di luar kendali aplikasi dan perlu disesuaikan secara terpisah di sisi server jika diperlukan.