### PR TITLE
Perbaiki statistik penduduk

### DIFF
--- a/app/Services/PendudukService.php
+++ b/app/Services/PendudukService.php
@@ -17,6 +17,7 @@ class PendudukService extends BaseApiService
         // Default parameter
         $defaultParams = [
             'filter[kode_kecamatan]' => str_replace('.', '', config('profil.kecamatan_id')),
+            'filter[status_dasar]' => 1,
         ];
 
         // Gabungkan parameter default dengan filter dinamis

--- a/app/Services/StatistikChartPendudukAgamaService.php
+++ b/app/Services/StatistikChartPendudukAgamaService.php
@@ -46,7 +46,7 @@ class StatistikChartPendudukAgamaService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'agama',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartPendudukGolDarahService.php
+++ b/app/Services/StatistikChartPendudukGolDarahService.php
@@ -45,7 +45,7 @@ class StatistikChartPendudukGolDarahService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'golongan-darah',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartPendudukPendidikanService.php
+++ b/app/Services/StatistikChartPendudukPendidikanService.php
@@ -44,7 +44,7 @@ class StatistikChartPendudukPendidikanService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'pendidikan-dalam-kk',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartPendudukPerkawinanService.php
+++ b/app/Services/StatistikChartPendudukPerkawinanService.php
@@ -46,7 +46,7 @@ class StatistikChartPendudukPerkawinanService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'status-perkawinan',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartPendudukService.php
+++ b/app/Services/StatistikChartPendudukService.php
@@ -45,7 +45,7 @@ class StatistikChartPendudukService extends BaseApiService
             try {                
                 $filters = [
                     'filter[id]' => 'jenis-kelamin',                    
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartPendudukUsiaService.php
+++ b/app/Services/StatistikChartPendudukUsiaService.php
@@ -46,7 +46,7 @@ class StatistikChartPendudukUsiaService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'rentang-umur',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;

--- a/app/Services/StatistikChartTingkatPendidikanService.php
+++ b/app/Services/StatistikChartTingkatPendidikanService.php
@@ -75,7 +75,7 @@ class StatistikChartTingkatPendidikanService extends BaseApiService
         $dataPendidikan = [];
         $filters = [
             'filter[id]' => 'pendidikan-dalam-kk',            
-            'filter[kecamatan]' => config('profil.kecamatan_id'),
+            'filter[kode_kecamatan]' => config('profil.kecamatan_id'),
         ];
         foreach (years_list() as $year) {
             $filters['filter[tahun]'] = $year;
@@ -103,7 +103,7 @@ class StatistikChartTingkatPendidikanService extends BaseApiService
         $filters = [
             'filter[id]' => 'pendidikan-dalam-kk',            
             'filter[tahun]' => $year,
-            'filter[kecamatan]' => config('profil.kecamatan_id'),
+            'filter[kode_kecamatan]' => config('profil.kecamatan_id'),
         ];
         $desaAll = (new DesaService)->listDesa();
         foreach ($desaAll as $desa) {
@@ -131,7 +131,7 @@ class StatistikChartTingkatPendidikanService extends BaseApiService
             'filter[id]' => 'pendidikan-dalam-kk',            
             'filter[tahun]' => $year,
             'filter[desa]' => $did,
-            'filter[kecamatan]' => config('profil.kecamatan_id'),
+            'filter[kode_kecamatan]' => config('profil.kecamatan_id'),
         ];
         
         try {
@@ -151,7 +151,7 @@ class StatistikChartTingkatPendidikanService extends BaseApiService
         $filters = [
             'filter[id]' => 'pendidikan-dalam-kk',     
             'filter[desa]' => $did,       
-            'filter[kecamatan]' => config('profil.kecamatan_id'),
+            'filter[kode_kecamatan]' => config('profil.kecamatan_id'),
         ];
         foreach (years_list() as $year) {
             $filters['filter[tahun]'] = $year;

--- a/app/Services/StatistikPendudukService.php
+++ b/app/Services/StatistikPendudukService.php
@@ -104,7 +104,7 @@ class StatistikPendudukService extends BaseApiService
                 $filters = [
                     'filter[id]' => 'jenis-kelamin',
                     'filter[tahun]' => $year,
-                    'filter[kecamatan]' => $this->kodeKecamatan,
+                    'filter[kode_kecamatan]' => $this->kodeKecamatan,
                 ];
                 if ($did != 'Semua') {
                     $filters['filter[desa]'] = $did;


### PR DESCRIPTION
issue # https://github.com/OpenSID/OpenDK/issues/1682
penyesuaian di API https://github.com/OpenSID/API-Database-Gabungan/pull/451
catatan : perbaikan statistik bukan hanya di sisi frontend tapi di dashboard juga terdapat ketidaksesuaian sehingga perlu diperbaiki

## 🎯 Deskripsi

Pull request ini memperbaiki ketidaksesuaian perhitungan jumlah penduduk dan pemfilteran data pada halaman Dashboard serta halaman publik Statistik Kependudukan ketika kondisi **Sinkronisasi Database Gabungan hidup (`isDatabaseGabungan() == true`)**.

Penyebab utama dari masalah sebelumnya antara lain:
1. Pada method `PendudukService::jumlahPenduduk()`, request ke endpoint API `/api/v1/opendk/sync-penduduk-opendk` tidak mengirimkan parameter filter status dasar penduduk (`filter[status_dasar] = 1`). Hal ini menyebabkan angka total penduduk yang ditampilkan pada Dashboard admin menghitung seluruh baris data yang ada di tabel server gabungan, termasuk penduduk dengan status mati, pindah, atau tidak aktif.
2. Pada servis statistik ringkasan (`StatistikPendudukService`) beserta 7 servis grafik/chart kependudukan, parameter pemfilteran kecamatan dikirimkan dengan kunci `filter[kecamatan]`, padahal endpoint API Database Gabungan (`OpenKab`) mengekspektasikan dan memvalidasi parameter menggunakan kunci `filter[kode_kecamatan]`.

Dengan PR ini, filter `filter[status_dasar] = 1` telah ditambahkan secara default pada pengambilan jumlah penduduk, dan penamaan parameter pemfilteran kecamatan telah diseragamkan menjadi `filter[kode_kecamatan]` pada seluruh servis statistik sehingga data yang ditampilkan akurat dan konsisten.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `app/Services/PendudukService.php`

**Fix — Penambahan filter status dasar penduduk aktif (`status_dasar = 1`):**

- Menambahkan parameter `'filter[status_dasar]' => 1` pada `$defaultParams` di method `jumlahPenduduk()` untuk memastikan hanya penduduk aktif/hidup yang dihitung.

```diff
  public function jumlahPenduduk(array $filters = [])
  {
      // Default parameter
      $defaultParams = [
          'filter[kode_kecamatan]' => str_replace('.', '', config('profil.kecamatan_id')),
+         'filter[status_dasar]' => 1,
      ];
```

### 2. `app/Services/StatistikPendudukService.php`

**Fix — Penyesuaian parameter filter kode kecamatan:**

- Mengubah nama kunci filter dari `'filter[kecamatan]'` menjadi `'filter[kode_kecamatan]'` pada method `dashboard()` yang mengambil data rekapitulasi untuk halaman Statistik Kependudukan.

```diff
  $filters = [
      'filter[id]' => 'jenis-kelamin',
      'filter[tahun]' => $year,
-     'filter[kecamatan]' => $this->kodeKecamatan,
+     'filter[kode_kecamatan]' => $this->kodeKecamatan,
  ];
```

### 3. Servis Grafik / Chart Kependudukan (`app/Services/StatistikChart*`)

**Fix — Penyesuaian serentak parameter `filter[kode_kecamatan]` pada servis grafik:**

- Mengubah kunci parameter dari `'filter[kecamatan]'` menjadi `'filter[kode_kecamatan]'` pada method yang bertugas mengambil data dari API Database Gabungan di 7 file servis berikut:
  - `app/Services/StatistikChartPendudukAgamaService.php`
  - `app/Services/StatistikChartPendudukGolDarahService.php`
  - `app/Services/StatistikChartPendudukPendidikanService.php`
  - `app/Services/StatistikChartPendudukPerkawinanService.php`
  - `app/Services/StatistikChartPendudukService.php`
  - `app/Services/StatistikChartPendudukUsiaService.php`
  - `app/Services/StatistikChartTingkatPendidikanService.php`

---

## ✅ Test Cases yang Diimplementasikan

- [x] Saat kondisi Sinkronisasi Database Gabungan aktif, angka jumlah penduduk pada halaman **Dashboard Admin** (`/dashboard`) mencerminkan jumlah penduduk aktif (`status_dasar = 1`), tidak lagi mencakup data penduduk yang sudah meninggal atau pindah.
- [x] Saat membuka halaman publik **Statistik Kependudukan** (`/statistik/kependudukan`), request API ke server Database Gabungan (`/api/v1/statistik-web/penduduk`) mengirimkan filter `filter[kode_kecamatan]` dengan benar sehingga ringkasan angka (Total, Laki-Laki, Perempuan, KTP, Akta, dll.) akurat.
- [x] Seluruh grafik/chart statistik kependudukan (Pertumbuhan per Tahun, Kategori Usia, Pendidikan dalam KK, Golongan Darah, Status Perkawinan, Agama, Tingkat Pendidikan) berhasil memuat data dari API gabungan tanpa mengalami kegagalan pemfilteran wilayah kecamatan.

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Pastikan aplikasi OpenDK dikonfigurasi dengan Sinkronisasi Database Gabungan aktif (`sinkronisasi_database_gabungan = 1` di database / pengaturan aplikasi).
2. Buka dan login ke antarmuka admin, lalu akses halaman **Dashboard** (`/dashboard`).
3. Periksa angka pada kotak **Penduduk** dan pastikan sesuai dengan total penduduk berstatus aktif/hidup (`status_dasar = 1`) di server Database Gabungan.
4. Akses halaman publik **Statistik Kependudukan** (`/statistik/kependudukan`).
5. Pilih filter desa dan tahun pada dropdown, lalu periksa:
   - ✅ Angka ringkasan dasbor kependudukan terisi dengan benar.
   - ✅ Seluruh grafik/chart kependudukan merender visualisasi data yang akurat sesuai kode kecamatan yang dikirimkan.

## 📸 Screenshot atau Video
<img width="1440" height="490" alt="image" src="https://github.com/user-attachments/assets/a5d50c55-1da2-4923-afc1-062ca51576c5" />
<img width="781" height="860" alt="image" src="https://github.com/user-attachments/assets/4ca70f6f-d394-4149-94cd-cbd70094011e" />

---

## ⚠️ Catatan Penting

> Penyesuaian nama parameter dari `filter[kecamatan]` menjadi `filter[kode_kecamatan]` diselaraskan dengan konvensi pemantauan *AllowedFilter* pada *Spatie Query Builder* di server API Database Gabungan (`OpenKab`), di mana *query filter* menargetkan kolom atau relasi berdasarkan `kode_kecamatan`.
