### PR TITLE
Fix: Prevent object injection via unserialize on LogViewer encrypted URL params

### DIFF
--- a/app/Http/Controllers/LogViewerController.php
+++ b/app/Http/Controllers/LogViewerController.php
@@ -81,11 +81,11 @@ class LogViewerController extends Controller
     {
         $folderFiles = [];
         if ($this->request->input('f')) {
-            $this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));
+            $this->log_viewer->setFolder(Crypt::decryptString($this->request->input('f')));
             $folderFiles = $this->log_viewer->getFolderFiles(true);
         }
         if ($this->request->input('l')) {
-            $this->log_viewer->setFile(Crypt::decrypt($this->request->input('l')));
+            $this->log_viewer->setFile(Crypt::decryptString($this->request->input('l')));
         }
 
         if ($early_return = $this->earlyReturn()) {
@@ -143,7 +143,7 @@ class LogViewerController extends Controller
     private function earlyReturn()
     {
         if ($this->request->input('f')) {
-            $this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));
+            $this->log_viewer->setFolder(Crypt::decryptString($this->request->input('f')));
         }
 
         if ($this->request->input('dl')) {
@@ -178,7 +178,7 @@ class LogViewerController extends Controller
      */
     private function pathFromInput($input_string)
     {
-        return $this->log_viewer->pathToLogFile(Crypt::decrypt($this->request->input($input_string)));
+        return $this->log_viewer->pathToLogFile(Crypt::decryptString($this->request->input($input_string)));
     }
 
     /**

--- a/resources/views/vendor/laravel-log-viewer/log.blade.php
+++ b/resources/views/vendor/laravel-log-viewer/log.blade.php
@@ -30,7 +30,7 @@
             <div class="box-body no-padding">
                 <ul class="nav nav-pills nav-stacked">
                     @foreach ($files as $file)
-                        <li @if ($current_file == $file) class="active" @endif><a href="?l={{ \Illuminate\Support\Facades\Crypt::encrypt($file) }}"> {{ $file }}
+                        <li @if ($current_file == $file) class="active" @endif><a href="?l={{ \Illuminate\Support\Facades\Crypt::encryptString($file) }}"> {{ $file }}
                             </a></li>
                     @endforeach
                 </ul>
@@ -43,22 +43,22 @@
                 <div class="p-3">
                     @if ($current_file)
                         <a class="btn btn-social btn-sm btn-success visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
-                            href="?dl={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}"
+                            href="?dl={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}"
                         >
                             <span class="fa fa-download"></span> Unduh
                         </a>
                         <a class="btn btn-social btn-sm btn-info visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block" id="clean-log"
-                            href="?clean={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}"
+                            href="?clean={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}"
                         >
                             <span class="fa fa-times-circle"></span> Bersihkan File
                         </a>
                         <a class="btn btn-social btn-sm btn-danger visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block" id="delete-log"
-                            href="?del={{ \Illuminate\Support\Facades\Crypt::encrypt($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}"
+                            href="?del={{ \Illuminate\Support\Facades\Crypt::encryptString($current_file) }}{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}"
                         >
                             <span class="fa fa-trash"></span> Hapus File
                         </a>
                         @if (count($files) > 1)
-                            <a id="delete-all-log" class="btn btn-social btn-sm btn-danger visible-sm-inline-block visible-md-inline-block visible-lg-inline-block" href="?delall=true{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encrypt($current_folder) : '' }}">
+                            <a id="delete-all-log" class="btn btn-social btn-sm btn-danger visible-sm-inline-block visible-md-inline-block visible-lg-inline-block" href="?delall=true{{ $current_folder ? '&f=' . \Illuminate\Support\Facades\Crypt::encryptString($current_folder) : '' }}">
                                 <span class="fa fa-trash"></span> Hapus Semua file
                             </a>
                         @endif

--- a/tests/Feature/LogViewerControllerTest.php
+++ b/tests/Feature/LogViewerControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2025 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2025 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\CompleteProfile;
+use App\Http\Middleware\GlobalShareMiddleware;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Crypt;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+
+uses(DatabaseTransactions::class);
+
+class ObjectInjectionGadget
+{
+    public static $wokenUp = false;
+
+    public function __wakeup()
+    {
+        self::$wokenUp = true;
+    }
+}
+
+beforeEach(function () {
+    ObjectInjectionGadget::$wokenUp = false;
+
+    $this->withoutMiddleware([
+        Authenticate::class,
+        RoleMiddleware::class,
+        PermissionMiddleware::class,
+        CompleteProfile::class,
+        GlobalShareMiddleware::class,
+    ]);
+});
+
+test('user-supplied log params are decrypted without unserialization', function () {
+    // Payload dibuat seolah-olah oleh penyerang yang memiliki APP_KEY:
+    // menyerupai Crypt::decrypt() lama (unserialize=true) terhadap input user.
+    // decryptString() mengembalikan string mentah tanpa unserialize, sehingga
+    // object tidak pernah diinstansiasi (tidak ada side effect __wakeup()).
+    $malicious = Crypt::encryptString(serialize(new ObjectInjectionGadget));
+
+    $this->get(route('setting.info-sistem').'?f='.urlencode($malicious));
+
+    expect(ObjectInjectionGadget::$wokenUp)->toBeFalse();
+});


### PR DESCRIPTION
# Pull Request: fix: Prevent object injection via unserialize on LogViewer encrypted URL params

## Description

Memperbaiki kerentanan CWE-502 (Deserialization of Untrusted Data) pada `LogViewerController`. Empat pemanggilan `Crypt::decrypt()` yang memproses parameter URL `f`, `l`, `dl`, `clean`, `del` dari request user memakai mode default `unserialize = true`, sehingga penyerang yang memiliki `APP_KEY` dapat mengirim *serialized object* berbahaya yang langsung di-`unserialize()`. Semua pemanggilan diganti ke `Crypt::decryptString()` (tanpa unserialize) karena nilai yang diharapkan adalah string path, sekaligus menambahkan test regresi.

### Changes made:

1. **[Security (Controller)]**: `app/Http/Controllers/LogViewerController.php` — mengganti 4 pemanggilan `Crypt::decrypt(...)` pada input user menjadi `Crypt::decryptString(...)` (baris 84, 88, 146, dan 181 — `pathFromInput` untuk flow download/clean/delete).
2. **[Security (View)]**: `resources/views/vendor/laravel-log-viewer/log.blade.php` — mengganti 5 pemanggilan `Crypt::encrypt(...)` menjadi `Crypt::encryptString(...)` agar proses round-trip tetap konsisten dengan `decryptString` (menghindari double-serialization).
3. **[Test (Regression)]**: `tests/Feature/LogViewerControllerTest.php` — test baru yang mengirim payload *serialized object* gadget (seolah-olah penyerang memiliki `APP_KEY`) ke route `setting.info-sistem` dan memastikan `__wakeup()` tidak terpanggil (object injection tidak terjadi).

### Reason for change:

- **Object injection / RCE**: `Crypt::decrypt()` secara default menjalankan `unserialize()` pada isi ciphertext. Karena payload berasal dari request user, penyerang yang memiliki `APP_KEY` bisa menyisipkan *serialized object* berbahaya → POP-chain → potensi RCE.
- **Nullify attack surface**: Dengan `decryptString`, nilai didekripsi sebagai string murni tanpa unserialize, sehingga seluruh attack vector object injection ditutup.
- **Konsistensi enkripsi**: View harus memakai `encryptString` agar nilai yang dikirim adalah string path mentah, bukan `serialize(path)`.

### Impact of change:

✅ **Security**: Menghilangkan `unserialize()` pada data tidak tepercaya — menutup CWE-502 / OWASP A08:2021.
✅ **Attack surface reduction**: Nilai terdekripsi kini hanya bisa berupa string path, memperkecil kemungkinan manipulasi tipe data.
✅ **Regression guard**: Test otomatis memastikan refactor tidak memperkenalkan kembali unserialize pada input user di masa depan.

## Related Issue

- Fixes https://github.com/OpenSID/wiki-keamanan/issues/58

## Steps to Reproduce

### Before fix (problem):
1. Penyerang memiliki `APP_KEY` (mis. terbaca dari `.env`, repo, atau known-key).
2. Penyerang membuat payload `Crypt::encryptString(serialize(new Gadget))`.
3. Navigasi ke `setting/info-sistem?f=<payload>`.
4. Server memanggil `Crypt::decrypt($f)` → `unserialize($f)` → object terinstansiasi (`__wakeup`/`__destruct` terpanggil).
5. ❌ Object injection / potensi RCE berhasil dilakukan.

### After fix (solution):
1. Server memanggil `Crypt::decryptString($f)` → nilai didekripsi sebagai string mentah tanpa unserialize.
2. Request berisi *serialized object* hanya menghasilkan string serialisasi, bukan instansiasi object.
3. ✅ `__wakeup()` gadget tidak pernah terpanggil — object injection tertutup.
4. ✅ Alur normal melihat/mengunduh/membersihkan/menghapus log tetap berfungsi.

### Testing on related features:
- Lihat file log (navigasi `?l=...`) ✅ Working
- Unduh file log (`?dl=...`) ✅ Working
- Bersihkan file log (`?clean=...`) ✅ Working
- Hapus file log (`?del=...`) ✅ Working
- Hapus semua file log (`?delall=true`) ✅ Working

## Checklist

- [x] Mengikuti aturan penulisan script (OpenSID)
- [x] Mengikuti proses review pull request
- [x] Membuat unit/integration test untuk memverifikasi fix
- [x] Manual testing dilakukan di environment development
- [x] Tidak ada console errors atau warnings
- [ ] Kode telah direview oleh minimal 1 orang

## Technical Details

### Technical Explanation

**Akar masalah:** `Illuminate\Encryption\Encrypter::decrypt($payload, $unserialize = true)` mengembalikan `unserialize($decrypted)` secara default. Semua panggilan di `LogViewerController` memakai default ini pada input user, sehingga isi ciphertext — yang bisa berisi *serialized object* buatan penyerang — di-unserialize.

```php
// Sebelum (rentan):
$this->log_viewer->setFolder(Crypt::decrypt($this->request->input('f')));

// Sesudah (aman):
$this->log_viewer->setFolder(Crypt::decryptString($this->request->input('f')));
```

`decryptString()` memanggil `decrypt($payload, false)` sehingga mengembalikan string mentah tanpa unserialize. Karena nilai yang dipakai seharusnya adalah path (string), ini tidak mengubah perilaku fungsional log viewer.

**Konsistensi view:** Semula view memakai `Crypt::encrypt($value)` = `encrypt(serialize($value))` (double-serialize). Diganti `Crypt::encryptString($value)` = `encrypt($value, false)` agar payload yang dikirim adalah string path mentah, yang konsisten dengan `decryptString()` di sisi server.

**Test regresi (`LogViewerControllerTest.php`):**
- Gadget class `ObjectInjectionGadget` memiliki `__wakeup()` yang menandai `static::$wokenUp = true`.
- Payload dikirim via `Crypt::encryptString(serialize(new ObjectInjectionGadget))` — meniru penyerang yang memiliki `APP_KEY`.
- Dengan `decryptString`, `__wakeup()` tidak terpanggil → test PASS. Jika dikembalikan ke `Crypt::decrypt` (unserialize=true), test FAIL → terbukti menangkap regresi (red/green terverifikasi).

### Configuration changes

Tidak ada perubahan konfigurasi. (Catatan: perubahan `DB_PASSWORD` di `.env.testing` hanya untuk environment testing lokal dan bukan bagian dari PR ini.)

### Dependencies added

No new dependencies

## Testing

### Manual Testing

- [ ] Login sebagai admin → menu Setting → Info Sistem (`/setting/info-sistem`)
- [ ] Klik file log untuk melihat isi log (parameter `l`)
- [ ] Klik tombol Unduh (parameter `dl`)
- [ ] Klik tombol Bersihkan File (parameter `clean`)
- [ ] Klik tombol Hapus File (parameter `del`)
- [ ] Klik tombol Hapus Semua File (parameter `delall`)
- [ ] Regression Testing — pastikan semua aksi log viewer tetap berfungsi normal

### Automated Testing

- [x] Pest — `tests/Feature/LogViewerControllerTest.php` — "user-supplied log params are decrypted without unserialization"

### Browser Compatibility (if applicable)

N/A — tidak ada perubahan visual UI

## Screenshots / Video

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6b980534-efb5-42b8-aa0f-e029f9a9d95e" />


## Breaking Changes

Tidak ada perubahan perilaku fungsional. Satu catatan: URL bookmark/link lama yang dibuat dengan `Crypt::encrypt()` (double-serialized) tidak lagi ter-resolve dengan benar setelah `decryptString()`. Secara fungsional, link tersebut berasal dari halaman itu sendiri dan selalu di-render ulang dengan `encryptString`, sehingga normalnya tidak bermasalah.

## Migration Guide

Not required

## References

- [Issue wiki-keamanan #58](https://github.com/OpenSID/wiki-keamanan/issues/58)
- [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)
- [OWASP A08:2021 – Software and Data Integrity Failures](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/)

---

**Additional notes:**
- Test dibuktikan red/green: dengan kode lama (`Crypt::decrypt`) test gagal (gadget `__wakeup` terpanggil), dengan kode baru (`decryptString`) test lulus.
- Nilai `APP_KEY` adalah secret yang tidak boleh bocor; fix ini mengurangi dampak bila key ter-expose (defense-in-depth), bukan pengganti untuk melindungi `APP_KEY`.
