### PR TITLE
Perbaikan entri anggota suplemen

### DIFF
--- a/app/Exports/ExportSuplemenTerdata.php
+++ b/app/Exports/ExportSuplemenTerdata.php
@@ -41,6 +41,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 class ExportSuplemenTerdata implements FromCollection, WithHeadings, WithMapping, WithStyles
 {
     protected $suplemenId;
+
     protected $filters;
 
     public function __construct($suplemenId = null, array $filters = [])
@@ -77,9 +78,6 @@ class ExportSuplemenTerdata implements FromCollection, WithHeadings, WithMapping
         return $query->get();
     }
 
-    /**
-     * @return array
-     */
     public function headings(): array
     {
         return [
@@ -99,10 +97,6 @@ class ExportSuplemenTerdata implements FromCollection, WithHeadings, WithMapping
         ];
     }
 
-    /**
-     * @param mixed $suplemenTerdata
-     * @return array
-     */
     public function map($suplemenTerdata): array
     {
         $penduduk = $suplemenTerdata->penduduk;
@@ -126,7 +120,6 @@ class ExportSuplemenTerdata implements FromCollection, WithHeadings, WithMapping
     }
 
     /**
-     * @param Worksheet $sheet
      * @return array
      */
     public function styles(Worksheet $sheet)

--- a/app/Exports/ExportSuplemenTerdataGabungan.php
+++ b/app/Exports/ExportSuplemenTerdataGabungan.php
@@ -35,25 +35,24 @@ use App\Models\DataDesa;
 use App\Models\Penduduk;
 use App\Models\SuplemenTerdata;
 use App\Services\PendudukService;
-use App\Support\Collection;
+use Illuminate\Support\Collection;
 
 class ExportSuplemenTerdataGabungan extends ExportSuplemenTerdata
 {
     /**
      * @param  array<int, int|string>  $pendudukGabunganIds
      */
-    public function __construct($suplemenId =
-     null, array $filters = [], array $pendudukGabunganIds = [])
+    public function __construct($suplemenId = null, array $filters = [], array $pendudukGabunganIds = [])
     {
-        //parent::__construct($suplemenId, $filters);
+        parent::__construct($suplemenId, $filters);
         $this->pendudukGabunganIds = array_map('intval', $pendudukGabunganIds);
     }
 
-    public function collection()
+    public function collection(): Collection
     {
-        $collection = new Collection();
+        $collection = parent::collection();
 
-        if (empty($this->pendudukGabunganIds)) {
+        if ($collection->isEmpty() || empty($this->pendudukGabunganIds)) {
             return $collection;
         }
 
@@ -116,9 +115,14 @@ class ExportSuplemenTerdataGabungan extends ExportSuplemenTerdata
             'tanggal_lahir' => $attributes['tanggallahir'] ?? $attributes['tanggal_lahir'] ?? null,
             'umur' => $attributes['umur'] ?? null,
             'sex' => $attributes['sex'] ?? null,
-            'alamat' => $attributes['alamat_wilayah'] ?? $attributes['alamat_wilayah'] ?? null,            
-        ]);                
-        $penduduk->setRelation('desa', new DataDesa(['nama' => $attributes['config']['nama_desa']]));
+            'alamat' => $attributes['alamat_sekarang'] ?? $attributes['alamat'] ?? null,
+        ]);
+
+        $penduduk->setRelation('desa', new DataDesa([
+            'nama' => data_get($attributes, 'config.nama_desa') ?? $attributes['nama_desa'] ?? null,
+            'desa_id' => data_get($attributes, 'config.kode_desa') ?? $attributes['kode_desa'] ?? null,
+        ]));
+
         return $penduduk;
     }
 }

--- a/app/Exports/ExportSuplemenTerdataGabungan.php
+++ b/app/Exports/ExportSuplemenTerdataGabungan.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+namespace App\Exports;
+
+use App\Models\DataDesa;
+use App\Models\Penduduk;
+use App\Models\SuplemenTerdata;
+use App\Services\PendudukService;
+use App\Support\Collection;
+
+class ExportSuplemenTerdataGabungan extends ExportSuplemenTerdata
+{
+    /**
+     * @param  array<int, int|string>  $pendudukGabunganIds
+     */
+    public function __construct($suplemenId =
+     null, array $filters = [], array $pendudukGabunganIds = [])
+    {
+        //parent::__construct($suplemenId, $filters);
+        $this->pendudukGabunganIds = array_map('intval', $pendudukGabunganIds);
+    }
+
+    public function collection()
+    {
+        $collection = new Collection();
+
+        if (empty($this->pendudukGabunganIds)) {
+            return $collection;
+        }
+
+        $missingIds = $this->pendudukGabunganIds;
+
+        foreach ($collection as $row) {
+            if ($row->penduduk_id_gabungan) {
+                $key = (int) $row->penduduk_id_gabungan;
+
+                if (isset($missingIds[$key])) {
+                    unset($missingIds[$key]);
+                }
+            }
+        }
+
+        if (empty($missingIds)) {
+            return $collection;
+        }
+
+        $resolved = (new PendudukService())->pendudukGabunganByIds(array_values($missingIds));
+
+        if ($resolved->isEmpty()) {
+            return $collection;
+        }
+
+        $resolvedMap = [];
+        foreach ($resolved as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $penduduk = $this->mapGabunganPenduduk($item);
+            $resolvedMap[(int) ($item['id'] ?? 0)] = $penduduk;
+        }
+
+        return $collection->map(function (SuplemenTerdata $row) use ($resolvedMap) {
+            if ($row->penduduk_id_gabungan && ! $row->penduduk) {
+                $penduduk = $resolvedMap[(int) $row->penduduk_id_gabungan] ?? null;
+
+                if ($penduduk) {
+                    $row->setRelation('penduduk', $penduduk);
+                }
+            }
+
+            return $row;
+        });
+    }
+
+    private function mapGabunganPenduduk(array $item): Penduduk
+    {
+        $attributes = $item['attributes'] ?? [];
+
+        $penduduk = new Penduduk();
+        $penduduk->forceFill([
+            'id' => $item['id'] ?? null,
+            'no_kk' => data_get($attributes, 'keluarga.no_kk') ?? $attributes['no_kk'] ?? null,
+            'nik' => $attributes['nik'] ?? null,
+            'nama' => $attributes['nama'] ?? null,
+            'tempat_lahir' => $attributes['tempatlahir'] ?? $attributes['tempat_lahir'] ?? null,
+            'tanggal_lahir' => $attributes['tanggallahir'] ?? $attributes['tanggal_lahir'] ?? null,
+            'umur' => $attributes['umur'] ?? null,
+            'sex' => $attributes['sex'] ?? null,
+            'alamat' => $attributes['alamat_wilayah'] ?? $attributes['alamat_wilayah'] ?? null,            
+        ]);                
+        $penduduk->setRelation('desa', new DataDesa(['nama' => $attributes['config']['nama_desa']]));
+        return $penduduk;
+    }
+}

--- a/app/Http/Controllers/Data/SuplemenController.php
+++ b/app/Http/Controllers/Data/SuplemenController.php
@@ -33,6 +33,7 @@ namespace App\Http\Controllers\Data;
 
 use App\Exports\ExportSuplemen;
 use App\Exports\ExportSuplemenTerdata;
+use App\Exports\ExportSuplemenTerdataGabungan;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\SuplemenRequest;
 use App\Http\Requests\SuplemenTerdataRequest;
@@ -45,8 +46,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
@@ -210,7 +209,12 @@ class SuplemenController extends Controller
     public function getDataSuplemenTerdata(Request $request, int $id_terdata): ?JsonResponse
     {
         if ($request->ajax()) {
-            $terdata = SuplemenTerdata::with('penduduk', 'penduduk.desa')->where('suplemen_id', $id_terdata)->get();
+            $desa = $request->input('desa');
+
+            $terdata = SuplemenTerdata::with('penduduk', 'penduduk.desa')
+                ->where('suplemen_id', $id_terdata)
+                ->when($desa && $desa !== 'Semua', fn ($query) => $query->where('desa_id', $desa))
+                ->get();
 
             if ($this->isDatabaseGabungan()) {
                 $pendudukGabungan = $this->pendudukGabunganBatch(
@@ -227,7 +231,7 @@ class SuplemenController extends Controller
                     }
 
                     return $row;
-                })->concat($this->suplemenTerdataGabungan($id_terdata, $request->input('desa')));
+                });
             }
 
             return DataTables::of($terdata)
@@ -307,7 +311,7 @@ class SuplemenController extends Controller
      */
     public function storeDetail(SuplemenTerdataRequest $request): RedirectResponse
     {
-        $data = $this->normalizePendudukSumber($request->validated());
+        $data = $this->normalizePendudukSumber($this->resolveDesaId($request->validated()));
 
         try {
             SuplemenTerdata::create($data);
@@ -343,14 +347,14 @@ class SuplemenController extends Controller
                 $penduduk = $this->pendudukGabunganBatch([$anggota->penduduk_id_gabungan])[(int) $anggota->penduduk_id_gabungan] ?? null;
             }
 
-            $selectedDesaId = $penduduk ? $penduduk->desa->desa_id : null;
+            $selectedDesaId = $penduduk?->desa?->desa_id ?? $anggota->desa_id;
 
             return view('data.data_suplemen.gabungan.edit_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'anggota', 'isDatabaseGabungan', 'penduduk', 'selectedDesaId'));
         }
 
         $desa = DataDesa::all();
         $data = $anggota->penduduk_id ? Penduduk::where('id', $anggota->penduduk_id)->get() : collect();
-        $selectedDesaId = optional($anggota->penduduk)->desa->desa_id;
+        $selectedDesaId = optional($anggota->penduduk)?->desa?->desa_id ?? $anggota->desa_id;
         $selectedPendudukId = optional($anggota->penduduk)->id;
 
         return view('data.data_suplemen.edit_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'data', 'desa', 'anggota', 'isDatabaseGabungan', 'selectedDesaId', 'selectedPendudukId'));
@@ -361,7 +365,7 @@ class SuplemenController extends Controller
      */
     public function updateDetail(SuplemenTerdataRequest $request, int $id): RedirectResponse
     {
-        $data = $this->normalizePendudukSumber($request->validated());
+        $data = $this->normalizePendudukSumber($this->resolveDesaId($request->validated()));
 
         try {
             SuplemenTerdata::findOrFail($id)->update($data);
@@ -417,9 +421,29 @@ class SuplemenController extends Controller
     public function exportTerdataExcel(Request $request, int $id): BinaryFileResponse
     {
         $suplemen = Suplemen::findOrFail($id);
-        $filters = $request->only(['desa', 'nama_penduduk']);
+        $filters = $request->only(['desa', 'nama_penduduk']);        
         $timestamp = date('Y-m-d-H-i-s');
         $filename = "data-suplemen-terdata-{$suplemen->slug}-{$timestamp}.xlsx";
+
+        if ($this->isDatabaseGabungan()) {
+            $query = SuplemenTerdata::query()->where('suplemen_id', $id);
+
+            if (!empty($filters['desa'])) {
+                $query->where(function ($q) use ($filters) {
+                    $q->where('desa_id', $filters['desa']);
+                });
+            }
+
+            if (!empty($filters['nama_penduduk'])) {
+                $query->whereHas('penduduk', function ($q) use ($filters) {
+                    $q->where('nama', 'like', '%' . $filters['nama_penduduk'] . '%');
+                });
+            }
+
+            $pendudukGabunganIds = $query->whereNotNull('penduduk_id_gabungan')->pluck('penduduk_id_gabungan')->filter()->values()->all();            
+
+            return Excel::download(new ExportSuplemenTerdataGabungan($id, $filters, $pendudukGabunganIds), $filename);
+        }
 
         return Excel::download(new ExportSuplemenTerdata($id, $filters), $filename);
     }
@@ -442,6 +466,29 @@ class SuplemenController extends Controller
     }
 
     /**
+     * Resolusi desa_id untuk anggota suplemen.
+     *
+     * Nilai desa_id dari form diutamakan. Fallback diambil dari respons API
+     * database gabungan (config.kode_desa) atau kolom desa_id das_penduduk
+     * untuk penduduk lokal.
+     */
+    private function resolveDesaId(array $data): array
+    {
+        if (! empty($data['desa_id'])) {
+            return $data;
+        }
+
+        if (! empty($data['penduduk_id_gabungan'])) {
+            $penduduk = $this->pendudukGabunganBatch([(int) $data['penduduk_id_gabungan']])[(int) $data['penduduk_id_gabungan']] ?? null;
+            $data['desa_id'] = $penduduk?->desa?->desa_id;
+        } elseif (! empty($data['penduduk_id'])) {
+            $data['desa_id'] = Penduduk::where('id', $data['penduduk_id'])->value('desa_id');
+        }
+
+        return $data;
+    }
+
+    /**
      * Resolusi beberapa penduduk dari database gabungan sekaligus (batch)
      * menggunakan filter id_penduduk berupa array, agar tidak melakukan
      * request berulang per anggota.
@@ -460,6 +507,10 @@ class SuplemenController extends Controller
             $penduduk = [];
 
             foreach ((new PendudukService())->pendudukGabunganByIds($ids) as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
                 $penduduk[(int) ($item['id'] ?? 0)] = $this->mapGabunganPenduduk($item);
             }
 
@@ -471,49 +522,6 @@ class SuplemenController extends Controller
             ]);
 
             return [];
-        }
-    }
-
-    /**
-     * Ambil anggota suplemen (terdata) dari API database gabungan.
-     *
-     * @return \Illuminate\Support\Collection<int, object>
-     */
-    private function suplemenTerdataGabungan(int $id, ?string $desa = null): Collection
-    {
-        try {
-            $response = Http::withHeaders($this->gabunganHeaders())
-                ->post($this->gabunganUrl("/api/v1/opendk/suplemen-terdata-datatable/{$id}"), [
-                    'page[size]' => 5000,
-                    'page[number]' => 1,
-                    'filter[kode_kecamatan]' => str_replace('.', '', (string) $this->profil->kecamatan_id),
-                    'filter[kode_desa]' => ($desa && $desa !== 'Semua') ? $desa : '',
-                ]);
-
-            if ($response->failed()) {
-                return collect();
-            }
-
-            return collect($response->json('data') ?? [])->map(function (array $item) use ($id) {
-                $attributes = $item['attributes'] ?? [];
-                $penduduk = $this->mapGabunganPenduduk($item);
-
-                return (object) [
-                    'id' => $item['id'] ?? null,
-                    'suplemen_id' => $id,
-                    'penduduk_id' => null,
-                    'penduduk_id_gabungan' => $item['id'] ?? null,
-                    'keterangan' => $attributes['keterangan'] ?? null,
-                    'penduduk' => $penduduk,
-                ];
-            })->values();
-        } catch (\Exception $e) {
-            Log::error('Suplemen terdata fetch from gabungan failed', [
-                'error' => $e->getMessage(),
-                'suplemen_id' => $id,
-            ]);
-
-            return collect();
         }
     }
 
@@ -543,25 +551,5 @@ class SuplemenController extends Controller
         $penduduk->setRelation('desa', $desa);
 
         return $penduduk;
-    }
-
-    /**
-     * Header otorisasi untuk API database gabungan.
-     */
-    private function gabunganHeaders(): array
-    {
-        return [
-            'Accept' => 'application/ld+json',
-            'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer ' . ($this->getSettings()['api_key_database_gabungan'] ?? ''),
-        ];
-    }
-
-    /**
-     * URL endpoint API database gabungan.
-     */
-    private function gabunganUrl(string $path): string
-    {
-        return rtrim((string) ($this->getSettings()['api_server_database_gabungan'] ?? ''), '/') . $path;
     }
 }

--- a/app/Http/Controllers/Data/SuplemenController.php
+++ b/app/Http/Controllers/Data/SuplemenController.php
@@ -34,24 +34,31 @@ namespace App\Http\Controllers\Data;
 use App\Exports\ExportSuplemen;
 use App\Exports\ExportSuplemenTerdata;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\SuplemenRequest;
+use App\Http\Requests\SuplemenTerdataRequest;
 use App\Models\DataDesa;
 use App\Models\Penduduk;
 use App\Models\Suplemen;
 use App\Models\SuplemenTerdata;
+use App\Services\PendudukService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Yajra\DataTables\DataTables;
 
 class SuplemenController extends Controller
 {
     /**
      * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(): View
     {
         $page_title = 'Data Suplemen';
         $page_description = 'Daftar Data Suplemen';
@@ -60,11 +67,11 @@ class SuplemenController extends Controller
     }
 
     /**
-     * Return datatable Data Suplemen
+     * Return datatable Data Suplemen.
      */
-    public function getDataSuplemen()
+    public function getDataSuplemen(Request $request): ?JsonResponse
     {
-        if (request()->ajax()) {
+        if ($request->ajax()) {
             return DataTables::of(Suplemen::withCount('terdata')->get())
                 ->addIndexColumn()
                 ->addColumn('aksi', function ($row) {
@@ -88,10 +95,8 @@ class SuplemenController extends Controller
 
     /**
      * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
      */
-    public function create()
+    public function create(): View
     {
         $page_title = 'Data Suplemen';
         $page_description = 'Tambah Data Suplemen';
@@ -101,19 +106,14 @@ class SuplemenController extends Controller
 
     /**
      * Store a newly created resource in storage.
-     *
-     * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(SuplemenRequest $request): RedirectResponse
     {
-        request()->validate([
-            'nama' => 'required',
-        ]);
-
-        $request['slug'] = Str::slug($request->nama);
+        $data = $request->validated();
+        $data['slug'] = Str::slug($data['nama']);
 
         try {
-            Suplemen::create($request->all());
+            Suplemen::create($data);
         } catch (\Exception $e) {
             Log::error('Suplemen creation failed', [
                 'error' => $e->getMessage(),
@@ -129,11 +129,8 @@ class SuplemenController extends Controller
 
     /**
      * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function edit($id)
+    public function edit(int $id): View
     {
         $suplemen = Suplemen::findOrFail($id);
         $page_title = 'Data Suplemen';
@@ -144,20 +141,14 @@ class SuplemenController extends Controller
 
     /**
      * Update the specified resource in storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(SuplemenRequest $request, int $id): RedirectResponse
     {
-        request()->validate([
-            'nama' => 'required',
-        ]);
-
-        $request['slug'] = Str::slug($request->nama);
+        $data = $request->validated();
+        $data['slug'] = Str::slug($data['nama']);
 
         try {
-            Suplemen::findOrFail($id)->update($request->all());
+            Suplemen::findOrFail($id)->update($data);
         } catch (\Exception $e) {
             Log::error('Suplemen update failed', [
                 'error' => $e->getMessage(),
@@ -173,11 +164,8 @@ class SuplemenController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(int $id): RedirectResponse
     {
         if (SuplemenTerdata::where('suplemen_id', $id)->exists()) {
             return redirect()->route('data.data-suplemen.index')->with('error', 'Tidak dapat menghapus Data Suplemen yang mempunyai anggota!');
@@ -200,46 +188,74 @@ class SuplemenController extends Controller
 
     /**
      * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function show($id)
+    public function show(int $id): View
     {
         $suplemen = Suplemen::findOrFail($id);
         $sasaran = ['1' => 'Penduduk', '2' => 'Keluarga/KK'];
         $page_title = 'Anggota Suplemen';
         $page_description = 'Anggota Suplemen: ' . ucwords(strtolower($suplemen->nama));
 
-        return view('data.data_suplemen.show', compact('page_title', 'page_description', 'suplemen', 'sasaran'));
+        $view = $this->isDatabaseGabungan() ? 'data.data_suplemen.gabungan.show' : 'data.data_suplemen.show';
+
+        return view($view, compact('page_title', 'page_description', 'suplemen', 'sasaran'));
     }
 
     /**
-     * Return datatable Data Suplemen Terdata
+     * Return datatable Data Suplemen Terdata.
+     *
+     * Saat database gabungan aktif, data dari API database gabungan
+     * (hasil sinkronisasi desa) digabungkan dengan data anggota lokal.
      */
-    public function getDataSuplemenTerdata($id_terdata)
+    public function getDataSuplemenTerdata(Request $request, int $id_terdata): ?JsonResponse
     {
-        if (request()->ajax()) {
-            return DataTables::of(SuplemenTerdata::with('penduduk', 'penduduk.desa')->where('suplemen_id', $id_terdata)->get())
+        if ($request->ajax()) {
+            $terdata = SuplemenTerdata::with('penduduk', 'penduduk.desa')->where('suplemen_id', $id_terdata)->get();
+
+            if ($this->isDatabaseGabungan()) {
+                $pendudukGabungan = $this->pendudukGabunganBatch(
+                    $terdata->pluck('penduduk_id_gabungan')->filter()->values()->all()
+                );
+
+                $terdata = $terdata->map(function (SuplemenTerdata $row) use ($pendudukGabungan) {
+                    if ($row->penduduk_id_gabungan && ! $row->penduduk) {
+                        $penduduk = $pendudukGabungan[(int) $row->penduduk_id_gabungan] ?? null;
+
+                        if ($penduduk) {
+                            $row->setRelation('penduduk', $penduduk);
+                        }
+                    }
+
+                    return $row;
+                })->concat($this->suplemenTerdataGabungan($id_terdata, $request->input('desa')));
+            }
+
+            return DataTables::of($terdata)
                 ->addIndexColumn()
                 ->addColumn('aksi', function ($row) {
-                    if (!auth()->guest()) {
-                        $data['edit_url'] = route('data.data-suplemen.editdetail', [$row->id, $row->suplemen_id]);
-                        $data['delete_url'] = route('data.data-suplemen.destroydetail', [$row->id, $row->suplemen_id]);
+                    if (! $row instanceof SuplemenTerdata) {
+                        return null;
                     }
+
+                    if (auth()->guest()) {
+                        return null;
+                    }
+
+                    $data['edit_url'] = auth()->user()->can('access.data.data_suplemen.edit') ? route('data.data-suplemen.editdetail', [$row->id, $row->suplemen_id]) : null;
+                    $data['delete_url'] = auth()->user()->can('access.data.data_suplemen.delete') ? route('data.data-suplemen.destroydetail', [$row->id, $row->suplemen_id]) : null;
 
                     return view('forms.aksi', $data);
                 })
                 ->editColumn('penduduk.sex', function ($row) {
                     $sex = ['1' => 'Laki-laki', '2' => 'Perempuan'];
 
-                    return $sex[$row->penduduk->sex];
+                    return $sex[$row->penduduk->sex] ?? '-';
                 })
                 ->make();
         }
     }
 
-    public function getPenduduk($desa, $suplemen)
+    public function getPenduduk(string $desa, int $suplemen): JsonResponse
     {
         $penduduk = [];
 
@@ -258,83 +274,97 @@ class SuplemenController extends Controller
 
     /**
      * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
      */
-    public function createDetail($id_suplemen)
+    public function createDetail(int $id_suplemen): View
     {
         $suplemen = Suplemen::findOrFail($id_suplemen);
         $sasaran = ['1' => 'Penduduk', '2' => 'Keluarga/KK'];
         $page_title = 'Anggota Suplemen';
         $page_description = 'Tambah Anggota Suplemen';
-        $desa = DataDesa::all();
         $anggota = null;
+        $isDatabaseGabungan = $this->isDatabaseGabungan();
 
-        if ($suplemen->sasaran == 1) {
-            $data = Penduduk::get();
+        if ($isDatabaseGabungan) {
+            $data = collect();
+            $desa = collect();
+            $view = 'data.data_suplemen.gabungan.create_detail';
         } else {
-            $data = Penduduk::where('kk_level', 1)->get();
+            $desa = DataDesa::all();
+            $view = 'data.data_suplemen.create_detail';
+
+            if ($suplemen->sasaran == 1) {
+                $data = Penduduk::get();
+            } else {
+                $data = Penduduk::where('kk_level', 1)->get();
+            }
         }
 
-        return view('data.data_suplemen.create_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'data', 'desa', 'anggota'));
+        return view($view, compact('page_title', 'page_description', 'suplemen', 'sasaran', 'data', 'desa', 'anggota', 'isDatabaseGabungan'));
     }
 
     /**
      * Store a newly created resource in storage.
-     *
-     * @return \Illuminate\Http\Response
      */
-    public function storeDetail(Request $request)
+    public function storeDetail(SuplemenTerdataRequest $request): RedirectResponse
     {
-        request()->validate(
-            ['penduduk_id' => 'required'],
-            ['penduduk_id.required' => 'isian warga atau penduduk wajib diisi']
-        );
+        $data = $this->normalizePendudukSumber($request->validated());
 
         try {
-            SuplemenTerdata::create($request->all());
+            SuplemenTerdata::create($data);
         } catch (\Exception $e) {
             Log::error('Suplemen Terdata creation failed', [
                 'error' => $e->getMessage(),
                 'user_id' => auth()->id(),
-                'suplemen_id' => $request['suplemen_id'],
+                'suplemen_id' => $request->input('suplemen_id'),
             ]);
 
             return back()->withInput()->with('error', 'Anggota Suplemen gagal ditambah!');
         }
 
-        return redirect()->route('data.data-suplemen.show', $request['suplemen_id'])->with('success', 'Anggota Suplemen berhasil ditambah!');
+        return redirect()->route('data.data-suplemen.show', $request->input('suplemen_id'))->with('success', 'Anggota Suplemen berhasil ditambah!');
     }
 
     /**
      * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function editDetail($id, $id_suplemen)
+    public function editDetail(int $id, int $id_suplemen): View
     {
         $suplemen = Suplemen::findOrFail($id_suplemen);
         $sasaran = ['1' => 'Penduduk', '2' => 'Keluarga/KK'];
         $page_title = 'Anggota Suplemen';
         $page_description = 'Ubah Anggota Suplemen';
-        $anggota = SuplemenTerdata::with('penduduk', 'penduduk.desa')->where('id', $id)->first();
-        $data = Penduduk::where('id', $anggota->penduduk_id)->get();
-        $desa = DataDesa::all();
+        $anggota = SuplemenTerdata::with('penduduk', 'penduduk.desa')->where('id', $id)->firstOrFail();
+        $isDatabaseGabungan = $this->isDatabaseGabungan();
 
-        return view('data.data_suplemen.edit_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'data', 'desa', 'anggota'));
+        if ($isDatabaseGabungan) {
+            $penduduk = null;
+
+            if ($anggota->penduduk_id_gabungan) {
+                $penduduk = $this->pendudukGabunganBatch([$anggota->penduduk_id_gabungan])[(int) $anggota->penduduk_id_gabungan] ?? null;
+            }
+
+            $selectedDesaId = $penduduk ? $penduduk->desa->desa_id : null;
+
+            return view('data.data_suplemen.gabungan.edit_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'anggota', 'isDatabaseGabungan', 'penduduk', 'selectedDesaId'));
+        }
+
+        $desa = DataDesa::all();
+        $data = $anggota->penduduk_id ? Penduduk::where('id', $anggota->penduduk_id)->get() : collect();
+        $selectedDesaId = optional($anggota->penduduk)->desa->desa_id;
+        $selectedPendudukId = optional($anggota->penduduk)->id;
+
+        return view('data.data_suplemen.edit_detail', compact('page_title', 'page_description', 'suplemen', 'sasaran', 'data', 'desa', 'anggota', 'isDatabaseGabungan', 'selectedDesaId', 'selectedPendudukId'));
     }
 
     /**
      * Update the specified resource in storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function updateDetail(Request $request, $id)
+    public function updateDetail(SuplemenTerdataRequest $request, int $id): RedirectResponse
     {
+        $data = $this->normalizePendudukSumber($request->validated());
+
         try {
-            SuplemenTerdata::findOrFail($id)->update($request->all());
+            SuplemenTerdata::findOrFail($id)->update($data);
         } catch (\Exception $e) {
             Log::error('Suplemen Terdata update failed', [
                 'error' => $e->getMessage(),
@@ -345,16 +375,13 @@ class SuplemenController extends Controller
             return back()->withInput()->with('error', 'Anggota Suplemen gagal diubah!');
         }
 
-        return redirect()->route('data.data-suplemen.show', $request['suplemen_id'])->with('success', 'Anggota Suplemen berhasil diubah!');
+        return redirect()->route('data.data-suplemen.show', $request->input('suplemen_id'))->with('success', 'Anggota Suplemen berhasil diubah!');
     }
 
     /**
      * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
      */
-    public function destroyDetail($id, $id_suplemen)
+    public function destroyDetail(int $id, int $id_suplemen): RedirectResponse
     {
         try {
             SuplemenTerdata::findOrFail($id)->delete();
@@ -374,11 +401,8 @@ class SuplemenController extends Controller
 
     /**
      * Export Excel data suplemen.
-     *
-     * @param Request $request
-     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function exportExcel(Request $request)
+    public function exportExcel(Request $request): BinaryFileResponse
     {
         $filters = $request->only(['nama', 'sasaran']);
         $timestamp = date('Y-m-d-H-i-s');
@@ -389,12 +413,8 @@ class SuplemenController extends Controller
 
     /**
      * Export Excel data suplemen terdata.
-     *
-     * @param Request $request
-     * @param int $id Suplemen ID
-     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function exportTerdataExcel(Request $request, $id)
+    public function exportTerdataExcel(Request $request, int $id): BinaryFileResponse
     {
         $suplemen = Suplemen::findOrFail($id);
         $filters = $request->only(['desa', 'nama_penduduk']);
@@ -402,5 +422,146 @@ class SuplemenController extends Controller
         $filename = "data-suplemen-terdata-{$suplemen->slug}-{$timestamp}.xlsx";
 
         return Excel::download(new ExportSuplemenTerdata($id, $filters), $filename);
+    }
+
+    /**
+     * Normalisasi sumber penduduk untuk anggota suplemen.
+     *
+     * Anggota hanya boleh berisi salah satu sumber: penduduk lokal (penduduk_id)
+     * atau penduduk dari database gabungan (penduduk_id_gabungan), tidak keduanya.
+     */
+    private function normalizePendudukSumber(array $validated): array
+    {
+        if (! empty($validated['penduduk_id_gabungan'])) {
+            $validated['penduduk_id'] = null;
+        } else {
+            $validated['penduduk_id_gabungan'] = null;
+        }
+
+        return $validated;
+    }
+
+    /**
+     * Resolusi beberapa penduduk dari database gabungan sekaligus (batch)
+     * menggunakan filter id_penduduk berupa array, agar tidak melakukan
+     * request berulang per anggota.
+     *
+     * @param  array<int, int|string>  $ids
+     *
+     * @return array<int, Penduduk>
+     */
+    private function pendudukGabunganBatch(array $ids): array
+    {
+        if (empty($ids)) {
+            return [];
+        }
+
+        try {
+            $penduduk = [];
+
+            foreach ((new PendudukService())->pendudukGabunganByIds($ids) as $item) {
+                $penduduk[(int) ($item['id'] ?? 0)] = $this->mapGabunganPenduduk($item);
+            }
+
+            return $penduduk;
+        } catch (\Exception $e) {
+            Log::error('Penduduk batch fetch from gabungan failed', [
+                'error' => $e->getMessage(),
+                'ids' => $ids,
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * Ambil anggota suplemen (terdata) dari API database gabungan.
+     *
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    private function suplemenTerdataGabungan(int $id, ?string $desa = null): Collection
+    {
+        try {
+            $response = Http::withHeaders($this->gabunganHeaders())
+                ->post($this->gabunganUrl("/api/v1/opendk/suplemen-terdata-datatable/{$id}"), [
+                    'page[size]' => 5000,
+                    'page[number]' => 1,
+                    'filter[kode_kecamatan]' => str_replace('.', '', (string) $this->profil->kecamatan_id),
+                    'filter[kode_desa]' => ($desa && $desa !== 'Semua') ? $desa : '',
+                ]);
+
+            if ($response->failed()) {
+                return collect();
+            }
+
+            return collect($response->json('data') ?? [])->map(function (array $item) use ($id) {
+                $attributes = $item['attributes'] ?? [];
+                $penduduk = $this->mapGabunganPenduduk($item);
+
+                return (object) [
+                    'id' => $item['id'] ?? null,
+                    'suplemen_id' => $id,
+                    'penduduk_id' => null,
+                    'penduduk_id_gabungan' => $item['id'] ?? null,
+                    'keterangan' => $attributes['keterangan'] ?? null,
+                    'penduduk' => $penduduk,
+                ];
+            })->values();
+        } catch (\Exception $e) {
+            Log::error('Suplemen terdata fetch from gabungan failed', [
+                'error' => $e->getMessage(),
+                'suplemen_id' => $id,
+            ]);
+
+            return collect();
+        }
+    }
+
+    /**
+     * Map respons penduduk API database gabungan (JSON:API) ke model Eloquent
+     * yang digunakan kolom datatable dan form anggota suplemen.
+     */
+    private function mapGabunganPenduduk(array $item): Penduduk
+    {
+        $attributes = $item['attributes'] ?? [];
+
+        $penduduk = new Penduduk();
+        $penduduk->forceFill([
+            'id' => $item['id'] ?? null,
+            'no_kk' => data_get($attributes, 'keluarga.no_kk') ?? $attributes['no_kk'] ?? null,
+            'nik' => $attributes['nik'] ?? null,
+            'nama' => $attributes['nama'] ?? null,
+            'tempat_lahir' => $attributes['tempatlahir'] ?? $attributes['tempat_lahir'] ?? null,
+            'tanggal_lahir' => $attributes['tanggallahir'] ?? $attributes['tanggal_lahir'] ?? null,
+            'sex' => $attributes['sex'] ?? null,
+            'alamat' => $attributes['alamat_sekarang'] ?? $attributes['alamat'] ?? null,
+        ]);
+
+        $desa = new DataDesa();
+        $desa->nama = data_get($attributes, 'config.nama_desa') ?? $attributes['nama_desa'] ?? null;
+        $desa->desa_id = data_get($attributes, 'config.kode_desa') ?? $attributes['kode_desa'] ?? null;
+        $penduduk->setRelation('desa', $desa);
+
+        return $penduduk;
+    }
+
+    /**
+     * Header otorisasi untuk API database gabungan.
+     */
+    private function gabunganHeaders(): array
+    {
+        return [
+            'Accept' => 'application/ld+json',
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . ($this->getSettings()['api_key_database_gabungan'] ?? ''),
+        ];
+    }
+
+    /**
+     * URL endpoint API database gabungan.
+     */
+    private function gabunganUrl(string $path): string
+    {
+        return rtrim((string) ($this->getSettings()['api_server_database_gabungan'] ?? ''), '/') . $path;
     }
 }

--- a/app/Http/Controllers/Data/SuplemenController.php
+++ b/app/Http/Controllers/Data/SuplemenController.php
@@ -421,7 +421,7 @@ class SuplemenController extends Controller
     public function exportTerdataExcel(Request $request, int $id): BinaryFileResponse
     {
         $suplemen = Suplemen::findOrFail($id);
-        $filters = $request->only(['desa', 'nama_penduduk']);        
+        $filters = $request->only(['desa', 'nama_penduduk']);
         $timestamp = date('Y-m-d-H-i-s');
         $filename = "data-suplemen-terdata-{$suplemen->slug}-{$timestamp}.xlsx";
 
@@ -440,7 +440,7 @@ class SuplemenController extends Controller
                 });
             }
 
-            $pendudukGabunganIds = $query->whereNotNull('penduduk_id_gabungan')->pluck('penduduk_id_gabungan')->filter()->values()->all();            
+            $pendudukGabunganIds = $query->whereNotNull('penduduk_id_gabungan')->pluck('penduduk_id_gabungan')->filter()->values()->all();
 
             return Excel::download(new ExportSuplemenTerdataGabungan($id, $filters, $pendudukGabunganIds), $filename);
         }

--- a/app/Http/Requests/SuplemenRequest.php
+++ b/app/Http/Requests/SuplemenRequest.php
@@ -7,7 +7,7 @@
  *
  * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
  *
- * Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  *
  * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
  * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
@@ -24,36 +24,34 @@
  *
  * @package    OpenDK
  * @author     Tim Pengembang OpenDesa
- * @copyright  Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
  * @link       https://github.com/OpenSID/opendk
  */
 
-namespace App\Models;
+namespace App\Http\Requests;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Http\FormRequest;
 
-class SuplemenTerdata extends Model
+class SuplemenRequest extends FormRequest
 {
-    use HasFactory;
-
-    protected $table = 'das_suplemen_terdata';
-
-    protected $fillable = [
-        'suplemen_id',
-        'penduduk_id',
-        'penduduk_id_gabungan',
-        'keterangan',
-    ];
-
-    public function suplemen()
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
     {
-        return $this->belongsTo(Suplemen::class);
+        return true;
     }
 
-    public function penduduk()
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
     {
-        return $this->belongsTo(Penduduk::class);
+        return [
+            'nama' => ['required', 'string', 'max:255'],
+            'sasaran' => ['required', 'in:1,2'],
+            'keterangan' => ['nullable', 'string'],
+        ];
     }
 }

--- a/app/Http/Requests/SuplemenTerdataRequest.php
+++ b/app/Http/Requests/SuplemenTerdataRequest.php
@@ -50,6 +50,7 @@ class SuplemenTerdataRequest extends FormRequest
     {
         return [
             'suplemen_id' => ['required', 'exists:das_suplemen,id'],
+            'desa_id' => ['required', 'string', 'max:13', 'not_in:Semua'],
             'penduduk_id' => ['nullable', 'integer'],
             'penduduk_id_gabungan' => ['nullable', 'integer'],
             'keterangan' => ['nullable', 'string'],
@@ -81,8 +82,12 @@ class SuplemenTerdataRequest extends FormRequest
      */
     public function messages(): array
     {
+        $sebutanDesa = config('setting.sebutan_desa');
+
         return [
             'penduduk_id.required' => 'isian warga atau penduduk wajib diisi',
+            'desa_id.required' => "isian {$sebutanDesa} wajib diisi",
+            'desa_id.not_in' => "isian {$sebutanDesa} wajib diisi",
         ];
     }
 }

--- a/app/Http/Requests/SuplemenTerdataRequest.php
+++ b/app/Http/Requests/SuplemenTerdataRequest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SuplemenTerdataRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'suplemen_id' => ['required', 'exists:das_suplemen,id'],
+            'penduduk_id' => ['nullable', 'integer'],
+            'penduduk_id_gabungan' => ['nullable', 'integer'],
+            'keterangan' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Pastikan hanya salah satu sumber penduduk yang diisi:
+     * penduduk lokal (penduduk_id) atau penduduk dari database gabungan (penduduk_id_gabungan).
+     */
+    public function withValidator(\Illuminate\Validation\Validator $validator): void
+    {
+        $validator->after(function ($validator) {
+            $hasLocal = $this->filled('penduduk_id');
+            $hasGabungan = $this->filled('penduduk_id_gabungan');
+
+            if (! $hasLocal && ! $hasGabungan) {
+                $validator->errors()->add('penduduk_id', 'isian warga atau penduduk wajib diisi');
+            }
+
+            if ($hasLocal && $hasGabungan) {
+                $validator->errors()->add('penduduk_id_gabungan', 'hanya boleh memilih salah satu, penduduk lokal atau penduduk database gabungan');
+            }
+        });
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     */
+    public function messages(): array
+    {
+        return [
+            'penduduk_id.required' => 'isian warga atau penduduk wajib diisi',
+        ];
+    }
+}

--- a/app/Services/PendudukService.php
+++ b/app/Services/PendudukService.php
@@ -128,7 +128,7 @@ class PendudukService extends BaseApiService
             'page[size]' => count($ids),
         ]);
 
-        return collect($data);
+        return collect($data)->filter(fn (mixed $item): bool => is_array($item));
     }
 
     /**

--- a/app/Services/PendudukService.php
+++ b/app/Services/PendudukService.php
@@ -3,14 +3,13 @@
 namespace App\Services;
 
 use App\Models\Penduduk;
-use App\Models\SettingAplikasi;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class PendudukService extends BaseApiService
 {
     /**
-     * Get Unique Desa
+     * Get Unique Desa.
      */
     public function jumlahPenduduk(array $filters = [])
     {
@@ -33,7 +32,7 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Get Unique Desa
+     * Get Unique Desa.
      */
     public function desa(array $filters = [])
     {
@@ -59,7 +58,7 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Export Data Penduduk
+     * Export Data Penduduk.
      */
     public function exportPenduduk($size, $number, $search)
     {
@@ -110,7 +109,30 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Export Data Penduduk
+     * Ambil beberapa data penduduk dari database gabungan sekaligus
+     * menggunakan filter id_penduduk berupa array.
+     *
+     * @param  array<int, int|string>  $ids
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendudukGabunganByIds(array $ids)
+    {
+        if (empty($ids)) {
+            return collect();
+        }
+
+        $data = $this->apiRequest('/api/v1/opendk/sync-penduduk-opendk', [
+            'filter[kode_kecamatan]' => str_replace('.', '', config('profil.kecamatan_id')),
+            'filter[id_penduduk]' => $ids,
+            'page[size]' => count($ids),
+        ]);
+
+        return collect($data);
+    }
+
+    /**
+     * Export Data Penduduk.
      */
     public function cekPendudukNikTanggalLahir($nik, $tgl_lhr = null)
     {

--- a/database/migrations/2026_09_07_000001_add_penduduk_id_gabungan_to_suplemen_terdata_table.php
+++ b/database/migrations/2026_09_07_000001_add_penduduk_id_gabungan_to_suplemen_terdata_table.php
@@ -7,7 +7,7 @@
  *
  * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
  *
- * Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  *
  * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
  * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
@@ -24,36 +24,36 @@
  *
  * @package    OpenDK
  * @author     Tim Pengembang OpenDesa
- * @copyright  Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
  * @link       https://github.com/OpenSID/opendk
  */
 
-namespace App\Models;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-
-class SuplemenTerdata extends Model
+class AddPendudukIdGabunganToSuplemenTerdataTable extends Migration
 {
-    use HasFactory;
-
-    protected $table = 'das_suplemen_terdata';
-
-    protected $fillable = [
-        'suplemen_id',
-        'penduduk_id',
-        'penduduk_id_gabungan',
-        'keterangan',
-    ];
-
-    public function suplemen()
+    /**
+     * Run the migrations.
+     */
+    public function up()
     {
-        return $this->belongsTo(Suplemen::class);
+        Schema::table('das_suplemen_terdata', function (Blueprint $table) {
+            $table->unsignedBigInteger('penduduk_id_gabungan')->nullable()->after('penduduk_id');
+            $table->unsignedInteger('penduduk_id')->nullable()->change();
+        });
     }
 
-    public function penduduk()
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
     {
-        return $this->belongsTo(Penduduk::class);
+        Schema::table('das_suplemen_terdata', function (Blueprint $table) {
+            $table->dropColumn('penduduk_id_gabungan');
+            $table->unsignedInteger('penduduk_id')->nullable(false)->change();
+        });
     }
 }

--- a/database/migrations/2026_09_07_000002_add_desa_id_to_suplemen_terdata_table.php
+++ b/database/migrations/2026_09_07_000002_add_desa_id_to_suplemen_terdata_table.php
@@ -7,7 +7,7 @@
  *
  * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
  *
- * Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  *
  * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
  * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
@@ -24,37 +24,37 @@
  *
  * @package    OpenDK
  * @author     Tim Pengembang OpenDesa
- * @copyright  Hak Cipta 2017 - 2024 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
  * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
  * @link       https://github.com/OpenSID/opendk
  */
 
-namespace App\Models;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-
-class SuplemenTerdata extends Model
+class AddDesaIdToSuplemenTerdataTable extends Migration
 {
-    use HasFactory;
-
-    protected $table = 'das_suplemen_terdata';
-
-    protected $fillable = [
-        'suplemen_id',
-        'desa_id',
-        'penduduk_id',
-        'penduduk_id_gabungan',
-        'keterangan',
-    ];
-
-    public function suplemen()
+    /**
+     * Run the migrations.
+     */
+    public function up()
     {
-        return $this->belongsTo(Suplemen::class);
+        Schema::table('das_suplemen_terdata', function (Blueprint $table) {
+            $table->string('desa_id', 13)->nullable()->after('suplemen_id');
+        });
+
+        DB::statement('UPDATE das_suplemen_terdata st JOIN das_penduduk p ON p.id = st.penduduk_id SET st.desa_id = p.desa_id WHERE st.desa_id IS NULL');
     }
 
-    public function penduduk()
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
     {
-        return $this->belongsTo(Penduduk::class);
+        Schema::table('das_suplemen_terdata', function (Blueprint $table) {
+            $table->dropColumn('desa_id');
+        });
     }
 }

--- a/resources/views/data/data_suplemen/create.blade.php
+++ b/resources/views/data/data_suplemen/create.blade.php
@@ -19,7 +19,7 @@
 
                     {!! html()->form('POST', route('data.data-suplemen.store'))->id('form-faq')->class(
                             'form-horizontal
-                                                                                                                                                                                form-label-left',
+                                                                                                                                                                                                                        form-label-left',
                         )->open() !!}
 
                     <div class="box-body">

--- a/resources/views/data/data_suplemen/form.blade.php
+++ b/resources/views/data/data_suplemen/form.blade.php
@@ -18,8 +18,8 @@
     <div class="col-md-6 col-sm-6 col-xs-12">
         {!! html()->textarea('keterangan')->class('textarea')->style(
                 'width: 100%; height: 200px; font-size: 14px;
-                                                                                line-height: 18px; border: 1px solid #dddddd; padding:
-                                                                                10px;',
+                                                                                                line-height: 18px; border: 1px solid #dddddd; padding:
+                                                                                                10px;',
             )->placeholder('Keterangan')->value(old('keterangan', isset($suplemen) ? $suplemen->keterangan : '')) !!}
     </div>
 </div>

--- a/resources/views/data/data_suplemen/form_detail.blade.php
+++ b/resources/views/data/data_suplemen/form_detail.blade.php
@@ -47,13 +47,14 @@
         </div>
     </div>
     <div class="form-group">
-        <label class="control-label col-md-3 col-sm-3 col-xs-12" for="penduduk_id">{{ $suplemen->sasaran == 2
-            ? 'Nama Kepala
-                                                                                                                        Keluarga'
-            : 'Nama Penduduk' }}</label>
+        <label class="control-label col-md-3 col-sm-3 col-xs-12"
+            for="penduduk_id">{{ $suplemen->sasaran == 2
+                ? 'Nama Kepala
+                                                                                                                                                Keluarga'
+                : 'Nama Penduduk' }}</label>
 
         <div class="col-md-6 col-sm-6 col-xs-12">
-            <select name="{{ $pendudukField }}" id="penduduk" class="form-control" disabled>
+            <select name="{{ $pendudukField }}" id="penduduk" class="form-control">
                 <option class="form-control" value="">Pilih Penduduk</option>
                 @foreach ($data as $penduduk)
                     <option {{ $selectedPendudukId == $penduduk['id'] ? 'selected' : '' }} value="{{ $penduduk['id'] }}">

--- a/resources/views/data/data_suplemen/form_detail.blade.php
+++ b/resources/views/data/data_suplemen/form_detail.blade.php
@@ -1,3 +1,9 @@
+@php
+    $isDatabaseGabungan = $isDatabaseGabungan ?? false;
+    $pendudukField = $isDatabaseGabungan ? 'penduduk_id_gabungan' : 'penduduk_id';
+    $selectedDesaId = $selectedDesaId ?? null;
+    $selectedPendudukId = $selectedPendudukId ?? null;
+@endphp
 {{ html()->hidden('suplemen_id', $suplemen->id) }}
 @if ($suplemen->sasaran == 3)
     <div class="form-group">
@@ -7,11 +13,7 @@
             <select name="desa_id" id="desa" class="form-control">
                 <option class="form-control" value="">Pilih {{ config('setting.sebutan_desa') }}</option>
                 @foreach ($desa as $item)
-                    @if ($anggota == null)
-                        <option value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
-                    @else
-                        <option {{ $anggota->penduduk->desa->desa_id == $item['desa_id'] ? 'selected' : '' }} value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
-                    @endif
+                    <option {{ $selectedDesaId == $item['desa_id'] ? 'selected' : '' }} value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
                 @endforeach
             </select>
         </div>
@@ -20,16 +22,12 @@
         <label class="control-label col-md-3 col-sm-3 col-xs-12" for="penduduk_id">Nama Penduduk</label>
 
         <div class="col-md-6 col-sm-6 col-xs-12">
-            <select name="penduduk_id" id="penduduk" class="form-control" disabled>
+            <select name="{{ $pendudukField }}" id="penduduk" class="form-control" disabled>
                 <option class="form-control" value="">Pilih penduduk</option>
                 @foreach ($data as $penduduk)
-                    @if ($anggota == null)
-                        <option value="{{ $penduduk['id'] }}">{{ $penduduk['nama'] }}</option>
-                    @else
-                        <option {{ $anggota->penduduk->id == $penduduk['id'] ? 'selected' : '' }} value="{{ $penduduk['id'] }}">
-                            {{ $penduduk['nama'] }}
-                        </option>
-                    @endif
+                    <option {{ $selectedPendudukId == $penduduk['id'] ? 'selected' : '' }} value="{{ $penduduk['id'] }}">
+                        {{ $penduduk['nama'] }}
+                    </option>
                 @endforeach
             </select>
         </div>
@@ -43,11 +41,7 @@
             <select name="desa_id" id="desa" class="form-control">
                 <option class="form-control" value="">Pilih {{ config('setting.sebutan_desa') }}</option>
                 @foreach ($desa as $item)
-                    @if ($anggota == null)
-                        <option value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
-                    @else
-                        <option {{ $anggota->penduduk->desa->desa_id == $item['desa_id'] ? 'selected' : '' }} value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
-                    @endif
+                    <option {{ $selectedDesaId == $item['desa_id'] ? 'selected' : '' }} value="{{ $item['desa_id'] }}">{{ $item['nama'] }}</option>
                 @endforeach
             </select>
         </div>
@@ -55,20 +49,16 @@
     <div class="form-group">
         <label class="control-label col-md-3 col-sm-3 col-xs-12" for="penduduk_id">{{ $suplemen->sasaran == 2
             ? 'Nama Kepala
-                                                                                                                Keluarga'
+                                                                                                                        Keluarga'
             : 'Nama Penduduk' }}</label>
 
         <div class="col-md-6 col-sm-6 col-xs-12">
-            <select name="penduduk_id" id="penduduk" class="form-control" disabled>
+            <select name="{{ $pendudukField }}" id="penduduk" class="form-control" disabled>
                 <option class="form-control" value="">Pilih Penduduk</option>
                 @foreach ($data as $penduduk)
-                    @if ($anggota == null)
-                        <option value="{{ $penduduk['id'] }}">{{ $penduduk['nama'] }}</option>
-                    @else
-                        <option {{ $anggota->penduduk->id == $penduduk['id'] ? 'selected' : '' }} value="{{ $penduduk['id'] }}">
-                            {{ $penduduk['nama'] }}
-                        </option>
-                    @endif
+                    <option {{ $selectedPendudukId == $penduduk['id'] ? 'selected' : '' }} value="{{ $penduduk['id'] }}">
+                        {{ $penduduk['nama'] }}
+                    </option>
                 @endforeach
             </select>
         </div>

--- a/resources/views/data/data_suplemen/gabungan/create_detail.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/create_detail.blade.php
@@ -1,0 +1,177 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="{{ route('data.data-suplemen.index') }}">Daftar Data Suplemen</a></li>
+            <li><a href="{{ route('data.data-suplemen.show', $suplemen->id) }}">Data Suplemen {{ $suplemen->nama }}</a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    {!! html()->form('POST', route('data.data-suplemen.storedetail'))->id('form-suiplemen-gabungan')->class('form-horizontal form-label-left')->open() !!}
+
+                    <div class="box-body">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-striped table-condensed">
+                                <tr>
+                                    <th class="col-md-2">Nama</th>
+                                    <td>: {{ $suplemen->nama }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Sasaran</th>
+                                    <td>: {{ $sasaran[$suplemen->sasaran] }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Keterangan</th>
+                                    <td>: {{ $suplemen->keterangan }}</td>
+                                </tr>
+                            </table>
+                        </div>
+                        <hr>
+                        <legend>Daftar Anggota Suplemen</legend>
+
+                        @if (count($errors) > 0)
+                            <div class="alert alert-danger">
+                                <strong>Ups!</strong> Ada beberapa masalah dengan masukan Anda.<br><br>
+                                <ul>
+                                    @foreach ($errors->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        @include('flash::message')
+
+                        {{ html()->hidden('suplemen_id', $suplemen->id) }}
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama
+                                {{ config('setting.sebutan_desa') }}</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                @include('layouts.fragments.select-desa', ['width' => '100%'])
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12" for="penduduk_id">{{ $suplemen->sasaran == 2 ? 'Nama Kepala Keluarga' : 'Nama Penduduk' }}</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                <select name="penduduk_id_gabungan" id="penduduk_id_gabungan" class="form-control" required>
+                                    <option class="form-control" value="">Pilih Penduduk</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12">Keterangan</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                {!! html()->textarea('keterangan')->class('textarea')->placeholder('Keterangan')->value(old('keterangan'))->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;') !!}
+                            </div>
+                        </div>
+                        <div class="ln_solid"></div>
+                    </div>
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.asset_select2')
+
+@push('scripts')
+    <script>
+        $(function() {            
+            var $penduduk = $('#penduduk_id_gabungan');
+            $('#list_desa').select2({                
+                width: '100%',
+            })
+
+            $penduduk.select2({
+                placeholder: 'Pilih Penduduk',
+                width: '100%',
+                minimumInputLength: 0,
+                allowClear: true,
+                ajax: {
+                    url: `{{ $settings['api_server_database_gabungan'] ?? '' }}/api/v1/opendk/sync-penduduk-opendk`,
+                    dataType: 'json',
+                    delay: 400,
+                    headers: {
+                        "Authorization": `Bearer {{ $settings['api_key_database_gabungan'] ?? '' }}`,
+                        "Accept": "application/ld+json"
+                    },
+                    data: function(params) {
+                        var data = {
+                            'filter[kode_kecamatan]': {{ str_replace('.', '', $profil->kecamatan_id) }},
+                            'filter[kode_desa]': $('#list_desa').val(),
+                            'filter[status_dasar]': 1,
+                            'filter[search]': params.term,
+                            'page[size]': 20,
+                            'page[number]': params.page || 1,
+                        };
+
+                        @if ((int) $suplemen->sasaran !== 1)
+                            data['filter[kk_level]'] = 1;
+                        @endif
+
+                        return data;
+                    },
+                    processResults: function(response, params) {
+                        params.page = params.page || 1;
+
+                        var total = (response.meta && response.meta.pagination && response.meta.pagination.total) || 0;
+
+                        return {
+                            results: $.map(response.data || [], function(item) {
+                                var attributes = item.attributes || {};
+
+                                return {
+                                    id: item.id,
+                                    text: attributes.nik ? attributes.nama + ' - ' + attributes.nik : attributes.nama,
+                                };
+                            }),
+                            pagination: {
+                                more: params.page * 20 < total
+                            }
+                        };
+                    },
+                    cache: true
+                }
+            });
+
+            function setPendudukEnabled(enabled) {
+                var instance = $penduduk.data('select2');
+                $penduduk.prop('disabled', !enabled);
+
+                if (instance) {
+                    instance._syncAttributes();
+                }
+            }
+
+            setPendudukEnabled(false);
+
+            $('#list_desa').on('change', function() {
+                var desa = $(this).val();
+                $penduduk.val(null).trigger('change');
+
+                setPendudukEnabled(!!desa && desa !== 'Semua');
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/data/data_suplemen/gabungan/create_detail.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/create_detail.blade.php
@@ -60,7 +60,7 @@
                                 {{ config('setting.sebutan_desa') }}</label>
 
                             <div class="col-md-6 col-sm-6 col-xs-12">
-                                @include('layouts.fragments.select-desa', ['width' => '100%'])
+                                @include('layouts.fragments.select-desa', ['selectAttributes' => ['name' => 'desa_id', 'required' => 'required']])
                             </div>
                         </div>
 
@@ -97,9 +97,9 @@
 
 @push('scripts')
     <script>
-        $(function() {            
+        $(function() {
             var $penduduk = $('#penduduk_id_gabungan');
-            $('#list_desa').select2({                
+            $('#list_desa').select2({
                 width: '100%',
             })
 

--- a/resources/views/data/data_suplemen/gabungan/edit_detail.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/edit_detail.blade.php
@@ -62,7 +62,7 @@
                                 {{ config('setting.sebutan_desa') }}</label>
 
                             <div class="col-md-6 col-sm-6 col-xs-12">
-                                @include('layouts.fragments.select-desa', ['selectedOption' => $selectedDesaId])
+                                @include('layouts.fragments.select-desa', ['selectAttributes' => ['name' => 'desa_id', 'required' => 'required'], 'selectedOption' => $selectedDesaId])
                             </div>
                         </div>
 
@@ -103,7 +103,7 @@
     <script>
         $(function() {
             var $penduduk = $('#penduduk_id_gabungan');
-            $('#list_desa').select2({                
+            $('#list_desa').select2({
                 width: '100%',
             })
 

--- a/resources/views/data/data_suplemen/gabungan/edit_detail.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/edit_detail.blade.php
@@ -1,0 +1,187 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="{{ route('data.data-suplemen.index') }}">Daftar Data Suplemen</a></li>
+            <li><a href="{{ route('data.data-suplemen.show', $suplemen->id) }}">Data Suplemen {{ $suplemen->nama }}</a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    @if (count($errors) > 0)
+                        <div class="alert alert-danger">
+                            <strong>Ups!</strong> Ada beberapa masalah dengan masukan Anda.<br><br>
+                            <ul>
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <!-- form start -->
+                    {!! html()->form('post', route('data.data-suplemen.updatedetail', $anggota->id))->id('form-suiplemen-gabungan')->class('form-horizontal form-label-left')->open() !!}
+
+                    <div class="box-body">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-striped table-condensed">
+                                <tr>
+                                    <th class="col-md-2">Nama</th>
+                                    <td>: {{ $suplemen->nama }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Sasaran</th>
+                                    <td>: {{ $sasaran[$suplemen->sasaran] }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Keterangan</th>
+                                    <td>: {{ $suplemen->keterangan }}</td>
+                                </tr>
+                            </table>
+                        </div>
+                        <hr>
+                        <legend>Daftar Anggota Suplemen</legend>
+
+                        {{ method_field('PUT') }}
+                        @include('flash::message')
+
+                        {{ html()->hidden('suplemen_id', $suplemen->id) }}
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama
+                                {{ config('setting.sebutan_desa') }}</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                @include('layouts.fragments.select-desa', ['selectedOption' => $selectedDesaId])
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12" for="penduduk_id">{{ $suplemen->sasaran == 2 ? 'Nama Kepala Keluarga' : 'Nama Penduduk' }}</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                <select name="penduduk_id_gabungan" id="penduduk_id_gabungan" class="form-control" required>
+                                    @if ($penduduk)
+                                        <option value="{{ $penduduk->id }}" selected>{{ trim($penduduk->nama . ' - ' . ($penduduk->nik ?? ''), ' -') }}</option>
+                                    @endif
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="control-label col-md-3 col-sm-3 col-xs-12">Keterangan</label>
+
+                            <div class="col-md-6 col-sm-6 col-xs-12">
+                                {!! html()->textarea('keterangan')->class('textarea')->placeholder('Keterangan')->value(old('keterangan', $anggota->keterangan))->style('width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;') !!}
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /.box-body -->
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.asset_select2')
+
+@push('scripts')
+    <script>
+        $(function() {
+            var $penduduk = $('#penduduk_id_gabungan');
+            $('#list_desa').select2({                
+                width: '100%',
+            })
+
+            $penduduk.select2({
+                placeholder: 'Pilih Penduduk',
+                width: '100%',
+                minimumInputLength: 0,
+                allowClear: true,
+                ajax: {
+                    url: `{{ $settings['api_server_database_gabungan'] ?? '' }}/api/v1/opendk/sync-penduduk-opendk`,
+                    dataType: 'json',
+                    delay: 400,
+                    headers: {
+                        "Authorization": `Bearer {{ $settings['api_key_database_gabungan'] ?? '' }}`,
+                        "Accept": "application/ld+json"
+                    },
+                    data: function(params) {
+                        var data = {
+                            'filter[kode_kecamatan]': {{ str_replace('.', '', $profil->kecamatan_id) }},
+                            'filter[kode_desa]': $('#list_desa').val(),
+                            'filter[status_dasar]': 1,
+                            'filter[search]': params.term,
+                            'page[size]': 20,
+                            'page[number]': params.page || 1,
+                        };
+
+                        @if ((int) $suplemen->sasaran !== 1)
+                            data['filter[kk_level]'] = 1;
+                        @endif
+
+                        return data;
+                    },
+                    processResults: function(response, params) {
+                        params.page = params.page || 1;
+
+                        var total = (response.meta && response.meta.pagination && response.meta.pagination.total) || 0;
+
+                        return {
+                            results: $.map(response.data || [], function(item) {
+                                var attributes = item.attributes || {};
+
+                                return {
+                                    id: item.id,
+                                    text: attributes.nik ? attributes.nama + ' - ' + attributes.nik : attributes.nama,
+                                };
+                            }),
+                            pagination: {
+                                more: params.page * 20 < total
+                            }
+                        };
+                    },
+                    cache: true
+                }
+            });
+
+            function setPendudukEnabled(enabled) {
+                var instance = $penduduk.data('select2');
+                $penduduk.prop('disabled', !enabled);
+
+                if (instance) {
+                    instance._syncAttributes();
+                }
+            }
+
+            function hasDesa() {
+                var desa = $('#list_desa').val();
+
+                return !!desa && desa !== 'Semua';
+            }
+
+            $('#list_desa').on('change', function() {
+                $penduduk.val(null).trigger('change');
+                setPendudukEnabled(hasDesa());
+            });
+
+            if (hasDesa()) {
+                setPendudukEnabled(true);
+            }
+        });
+    </script>
+@endpush

--- a/resources/views/data/data_suplemen/gabungan/show.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/show.blade.php
@@ -21,6 +21,9 @@
                 <a href="{{ route('data.data-suplemen.createdetail', $suplemen->id) }}" class="btn btn-primary btn-sm" judul="Tambah Data">
                     <i class="fa fa-plus"></i>&ensp;Tambah
                 </a>
+                @include('forms.btn-social', [
+                    'export_url' => route('data.data-suplemen.export-terdata-excel', $suplemen->id),
+                ])
             </div>
             <div class="box-body">
                 <div class="table-responsive">
@@ -138,6 +141,20 @@
             $('#list_desa').on('select2:select', function(e) {
                 data.ajax.reload();
             });
+        });
+    </script>
+
+    <script type="text/javascript">
+        $(document).ready(function() {
+            var exportUrl = $('#export-url');
+
+            if (exportUrl.length && $('#list_desa').length) {
+                $('#list_desa').on('change', function() {
+                    var url = new URL(exportUrl.attr('href'));
+                    url.searchParams.set('desa', $(this).val() || 'Semua');
+                    exportUrl.attr('href', url.toString());
+                });
+            }
         });
     </script>
     @include('forms.datatable-vertical')

--- a/resources/views/data/data_suplemen/gabungan/show.blade.php
+++ b/resources/views/data/data_suplemen/gabungan/show.blade.php
@@ -1,0 +1,145 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="{{ route('data.data-suplemen.index') }}">Data Suplemen</a></li>
+            <li class="active">Data Suplemen {{ $suplemen->nama }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+
+        @include('partials.flash_message')
+
+        <div class="box box-primary">
+            <div class="box-header with-border">
+                <a href="{{ route('data.data-suplemen.createdetail', $suplemen->id) }}" class="btn btn-primary btn-sm" judul="Tambah Data">
+                    <i class="fa fa-plus"></i>&ensp;Tambah
+                </a>
+            </div>
+            <div class="box-body">
+                <div class="table-responsive">
+                    <table class="table table-bordered table-striped table-condensed">
+                        <tr>
+                            <th class="col-md-2">Nama</th>
+                            <td>: {{ $suplemen->nama }}</td>
+                        </tr>
+                        <tr>
+                            <th>Sasaran</th>
+                            <td>: {{ $sasaran[$suplemen->sasaran] }}</td>
+                        </tr>
+                        <tr>
+                            <th>Keterangan</th>
+                            <td>: {{ $suplemen->keterangan }}</td>
+                        </tr>
+                    </table>
+                </div>
+                <hr>
+                <legend>Daftar Anggota Suplemen</legend>
+                @include('layouts.fragments.list-desa')
+                <hr>
+                <div class="table-responsive">
+                    <table class="table table-striped table-bordered" id="suplemen-terdata-table">
+                        <thead>
+                            <tr>
+                                <th style="max-width: 80px;">Aksi</th>
+                                <th>{{ config('setting.sebutan_desa') }}</th>
+                                <th>No. KK</th>
+                                <th>NIK Penduduk</th>
+                                <th>Nama Penduduk</th>
+                                <th>Tempat Lahir</th>
+                                <th>Tanggal Lahir</th>
+                                <th>Jenis Kelamin</th>
+                                <th>Alamat</th>
+                                <th>Keterangan</th>
+                            </tr>
+                        </thead>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.asset_select2')
+@include('partials.asset_datatables')
+
+@push('scripts')
+    <script type="text/javascript">
+        $(document).ready(function() {
+            $('#list_desa').select2();
+
+            var data = $('#suplemen-terdata-table').DataTable({
+                processing: true,
+                serverSide: true,
+                ajax: {
+                    url: "{!! route('data.data-suplemen.getsuplementerdata', $suplemen->id) !!}",
+                    type: "POST",
+                    data: function(row) {
+                        return {
+                            desa: $('#list_desa').val()
+                        };
+                    }
+                },
+                columns: [{
+                        data: 'aksi',
+                        name: 'aksi',
+                        class: 'text-center',
+                        searchable: false,
+                        orderable: false
+                    },
+                    {
+                        data: 'penduduk.desa.nama',
+                        name: 'penduduk.desa.nama'
+                    },
+                    {
+                        data: 'penduduk.no_kk',
+                        name: 'penduduk.no_kk'
+                    },
+                    {
+                        data: 'penduduk.nik',
+                        name: 'penduduk.nik'
+                    },
+                    {
+                        data: 'penduduk.nama',
+                        name: 'penduduk.nama'
+                    },
+                    {
+                        data: 'penduduk.tempat_lahir',
+                        name: 'penduduk.tempat_lahir'
+                    },
+                    {
+                        data: 'penduduk.tanggal_lahir',
+                        name: 'penduduk.tanggal_lahir'
+                    },
+                    {
+                        data: 'penduduk.sex',
+                        name: 'penduduk.sex'
+                    },
+                    {
+                        data: 'penduduk.alamat',
+                        name: 'penduduk.alamat'
+                    },
+                    {
+                        data: 'keterangan',
+                        name: 'keterangan'
+                    },
+                ],
+                order: [
+                    [1, 'asc']
+                ]
+            });
+
+            $('#list_desa').on('select2:select', function(e) {
+                data.ajax.reload();
+            });
+        });
+    </script>
+    @include('forms.datatable-vertical')
+    @include('forms.delete-modal')
+@endpush

--- a/resources/views/data/data_suplemen/show.blade.php
+++ b/resources/views/data/data_suplemen/show.blade.php
@@ -46,6 +46,7 @@
                 </div>
                 <hr>
                 <legend>Daftar Anggota Suplemen</legend>
+                @include('layouts.fragments.list-desa')
                 <div class="table-responsive">
                     <table class="table table-striped table-bordered" id="suplemen-terdata-table">
                         <thead>
@@ -129,6 +130,20 @@
                     [1, 'asc']
                 ]
             });
+        });
+    </script>
+
+    <script type="text/javascript">
+        $(document).ready(function() {
+            var exportUrl = $('#export-url');
+
+            if (exportUrl.length && $('#list_desa').length) {
+                $('#list_desa').on('change', function() {
+                    var url = new URL(exportUrl.attr('href'));
+                    url.searchParams.set('desa', $(this).val() || 'Semua');
+                    exportUrl.attr('href', url.toString());
+                });
+            }
         });
     </script>
     @include('forms.datatable-vertical')

--- a/resources/views/forms/btn-social.blade.php
+++ b/resources/views/forms/btn-social.blade.php
@@ -15,7 +15,7 @@
 @endif
 
 @if (isset($export_url))
-    <a href="{{ $export_url }}">
+    <a href="{{ $export_url }}" id="export-url">
         <button type="button" class="btn btn-primary btn-sm btn-social" title="{{ $export_text ?? 'Ekspor' }}">
             <i class="fa fa-upload"></i>{{ $export_text ?? 'Ekspor' }}
         </button>

--- a/tests/Feature/Data/SuplemenControllerRequestTest.php
+++ b/tests/Feature/Data/SuplemenControllerRequestTest.php
@@ -127,6 +127,7 @@ test('storeDetail membuat anggota suplemen saat data valid', function () {
 
     $response = $this->post(route('data.data-suplemen.storedetail'), [
         'suplemen_id' => $suplemen->id,
+        'desa_id' => $penduduk->desa_id,
         'penduduk_id' => $penduduk->id,
         'keterangan' => 'Anggota baru',
     ]);
@@ -170,6 +171,7 @@ test('updateDetail mengubah anggota suplemen saat data valid', function () {
 
     $response = $this->put(route('data.data-suplemen.updatedetail', $terdata->id), [
         'suplemen_id' => $suplemen->id,
+        'desa_id' => $penduduk->desa_id,
         'penduduk_id' => $penduduk->id,
         'keterangan' => 'Keterangan diubah',
     ]);

--- a/tests/Feature/Data/SuplemenControllerRequestTest.php
+++ b/tests/Feature/Data/SuplemenControllerRequestTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\CompleteProfile;
+use App\Http\Middleware\GlobalShareMiddleware;
+use App\Models\Penduduk;
+use App\Models\SettingAplikasi;
+use App\Models\Suplemen;
+use App\Models\SuplemenTerdata;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->withViewErrors([]);
+    $this->withoutMiddleware([
+        Authenticate::class,
+        RoleMiddleware::class,
+        PermissionMiddleware::class,
+        CompleteProfile::class,
+        GlobalShareMiddleware::class,
+    ]);
+
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '0']
+    );
+});
+
+test('store membuat data suplemen dengan data valid', function () {
+    $response = $this->post(route('data.data-suplemen.store'), [
+        'nama' => 'Suplemen Valid',
+        'sasaran' => '1',
+        'keterangan' => 'Keterangan valid',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.index'));
+    $response->assertSessionHas('success', 'Data Suplemen berhasil ditambah!');
+
+    $this->assertDatabaseHas('das_suplemen', [
+        'nama' => 'Suplemen Valid',
+        'slug' => 'suplemen-valid',
+        'sasaran' => '1',
+    ]);
+});
+
+test('store gagal ketika nama kosong', function () {
+    $response = $this->post(route('data.data-suplemen.store'), [
+        'nama' => '',
+        'sasaran' => '1',
+    ]);
+
+    $response->assertSessionHasErrors(['nama']);
+});
+
+test('store gagal ketika sasaran tidak valid', function () {
+    $response = $this->post(route('data.data-suplemen.store'), [
+        'nama' => 'Suplemen Sasaran',
+        'sasaran' => '3',
+    ]);
+
+    $response->assertSessionHasErrors(['sasaran']);
+});
+
+test('update mengubah data suplemen saat data valid', function () {
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Lama',
+        'slug' => 'suplemen-lama',
+        'sasaran' => 1,
+    ]);
+
+    $response = $this->put(route('data.data-suplemen.update', $suplemen->id), [
+        'nama' => 'Suplemen Baru',
+        'sasaran' => '2',
+        'keterangan' => 'Keterangan baru',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.index'));
+    $response->assertSessionHas('success', 'Data Suplemen berhasil diubah!');
+
+    $this->assertDatabaseHas('das_suplemen', [
+        'id' => $suplemen->id,
+        'nama' => 'Suplemen Baru',
+        'slug' => 'suplemen-baru',
+        'sasaran' => '2',
+    ]);
+});
+
+test('storeDetail membuat anggota suplemen saat data valid', function () {
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Anggota',
+        'slug' => 'suplemen-anggota',
+        'sasaran' => 1,
+    ]);
+    $penduduk = Penduduk::factory()->create();
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Anggota baru',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil ditambah!');
+
+    expect(SuplemenTerdata::where('suplemen_id', $suplemen->id)->count())->toBe(1);
+});
+
+test('storeDetail gagal ketika sumber penduduk kosong dengan pesan kustom', function () {
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Anggota',
+        'slug' => 'suplemen-anggota',
+        'sasaran' => 1,
+    ]);
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $suplemen->id,
+        'keterangan' => 'Tanpa penduduk',
+    ]);
+
+    $response->assertSessionHasErrors(['penduduk_id']);
+
+    $errors = session('errors');
+    expect($errors->first('penduduk_id'))->toBe('isian warga atau penduduk wajib diisi');
+});
+
+test('updateDetail mengubah anggota suplemen saat data valid', function () {
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Anggota',
+        'slug' => 'suplemen-anggota',
+        'sasaran' => 1,
+    ]);
+    $penduduk = Penduduk::factory()->create();
+    $terdata = SuplemenTerdata::create([
+        'suplemen_id' => $suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Keterangan awal',
+    ]);
+
+    $response = $this->put(route('data.data-suplemen.updatedetail', $terdata->id), [
+        'suplemen_id' => $suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Keterangan diubah',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil diubah!');
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'id' => $terdata->id,
+        'keterangan' => 'Keterangan diubah',
+    ]);
+});

--- a/tests/Feature/Data/SuplemenGabunganTest.php
+++ b/tests/Feature/Data/SuplemenGabunganTest.php
@@ -1,0 +1,392 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2026 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\CompleteProfile;
+use App\Http\Middleware\GlobalShareMiddleware;
+use App\Models\Penduduk;
+use App\Models\SettingAplikasi;
+use App\Models\Suplemen;
+use App\Models\SuplemenTerdata;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Http;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+
+uses(DatabaseTransactions::class);
+
+function aktifkanDatabaseGabungan(bool $aktif = true): void
+{
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => $aktif ? '1' : '0']
+    );
+
+    if ($aktif) {
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'api_server_database_gabungan'],
+            ['value' => 'https://api.example.com']
+        );
+        SettingAplikasi::updateOrCreate(
+            ['key' => 'api_key_database_gabungan'],
+            ['value' => 'test-api-key']
+        );
+    }
+}
+
+/**
+ * Fake seluruh panggilan API database gabungan.
+ *
+ * Constructor controller memanggil DesaService::listDesa() sehingga setiap
+ * request saat mode gabungan aktif wajib memiliki stub catch-all.
+ */
+function fakeGabunganApi(array $routes = []): void
+{
+    Http::fake(array_merge($routes, [
+        '*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+    ]));
+}
+
+beforeEach(function () {
+    $this->withViewErrors([]);
+    $this->withoutMiddleware([
+        Authenticate::class,
+        RoleMiddleware::class,
+        PermissionMiddleware::class,
+        CompleteProfile::class,
+        GlobalShareMiddleware::class,
+    ]);
+
+    aktifkanDatabaseGabungan(false);
+
+    $this->suplemen = Suplemen::create([
+        'nama' => 'Suplemen Gabungan Test',
+        'slug' => 'suplemen-gabungan-test',
+        'sasaran' => 1,
+        'keterangan' => 'Testing database gabungan',
+    ]);
+});
+
+test('show menampilkan view gabungan saat database gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $response = $this->get(route('data.data-suplemen.show', $this->suplemen->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.gabungan.show');
+    $response->assertViewHas('suplemen', fn (Suplemen $suplemen) => $suplemen->id === $this->suplemen->id);
+});
+
+test('show menampilkan view lokal saat database gabungan tidak aktif', function () {
+    $response = $this->get(route('data.data-suplemen.show', $this->suplemen->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.show');
+    $response->assertViewHas('suplemen', fn (Suplemen $suplemen) => $suplemen->id === $this->suplemen->id);
+});
+
+test('createDetail menampilkan view gabungan saat database gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $response = $this->get(route('data.data-suplemen.createdetail', $this->suplemen->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.gabungan.create_detail');
+    $response->assertViewHas('isDatabaseGabungan', true);
+    $response->assertSee('api.example.com/api/v1/opendk/sync-penduduk-opendk');
+    $response->assertSee('filter[kode_desa]');
+    $response->assertSee('select2({');
+    $response->assertSee('minimumInputLength: 0');
+    $response->assertSee("$('#penduduk_id_gabungan')", false);
+});
+
+test('createDetail menampilkan view lokal saat database gabungan tidak aktif', function () {
+    $response = $this->get(route('data.data-suplemen.createdetail', $this->suplemen->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.create_detail');
+    $response->assertViewHas('isDatabaseGabungan', false);
+});
+
+test('storeDetail menyimpan penduduk dari database gabungan saat gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Anggota dari gabungan',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil ditambah!');
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => null,
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Anggota dari gabungan',
+    ]);
+});
+
+test('storeDetail menyimpan penduduk lokal saat database gabungan tidak aktif', function () {
+    $penduduk = Penduduk::factory()->create();
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Anggota lokal',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil ditambah!');
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'penduduk_id_gabungan' => null,
+    ]);
+});
+
+test('storeDetail gagal ketika penduduk lokal dan gabungan keduanya diisi', function () {
+    $penduduk = Penduduk::factory()->create();
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'penduduk_id_gabungan' => 99,
+    ]);
+
+    $response->assertSessionHasErrors(['penduduk_id_gabungan']);
+});
+
+test('getDataSuplemenTerdata menggabungkan anggota lokal dan API database gabungan', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi([
+        'https://api.example.com/api/v1/opendk/suplemen-terdata-datatable/*' => Http::response([
+            'data' => [
+                [
+                    'id' => 100,
+                    'attributes' => [
+                        'nama_desa' => 'Desa API',
+                        'no_kk' => '1234567890123456',
+                        'nik' => '1234567890123457',
+                        'nama' => 'Anggota Dari API',
+                        'tempat_lahir' => 'Jakarta',
+                        'tanggal_lahir' => '1990-01-01',
+                        'sex' => 1,
+                        'alamat' => 'Alamat API',
+                        'keterangan' => 'Terdata desa',
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['total' => 1]],
+        ], 200),
+    ]);
+
+    $penduduk = Penduduk::factory()->create(['nama' => 'Anggota Lokal']);
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Anggota lokal',
+    ]);
+
+    $response = $this->postJson(
+        route('data.data-suplemen.getsuplementerdata', $this->suplemen->id),
+        [],
+        ['X-Requested-With' => 'XMLHttpRequest']
+    );
+
+    $response->assertStatus(200);
+    $data = collect($response->json('data'));
+
+    expect($data->pluck('keterangan'))->toContain('Anggota lokal')
+        ->and($data->pluck('keterangan'))->toContain('Terdata desa')
+        ->and($data->pluck('penduduk.nama'))->toContain('Anggota Lokal')
+        ->and($data->pluck('penduduk.nama'))->toContain('Anggota Dari API');
+});
+
+test('getDataSuplemenTerdata menyelesaikan penduduk gabungan lokal dalam satu request batch', function () {
+    aktifkanDatabaseGabungan(true);
+
+    $batchCalls = 0;
+    $sentIds = null;
+
+    Http::fake([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => function (\Illuminate\Http\Client\Request $request) use (&$batchCalls, &$sentIds) {
+            $batchCalls++;
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            $sentIds = $query['filter']['id_penduduk'] ?? null;
+
+            return Http::response([
+                'data' => [
+                    ['id' => 500, 'attributes' => ['nama' => 'Penduduk Gabungan 1', 'nik' => '123', 'sex' => 1]],
+                    ['id' => 501, 'attributes' => ['nama' => 'Penduduk Gabungan 2', 'nik' => '124', 'sex' => 2]],
+                ],
+                'meta' => ['pagination' => ['total' => 2]],
+            ], 200);
+        },
+        'https://api.example.com/api/v1/opendk/suplemen-terdata-datatable/*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+        '*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+    ]);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 500,
+        'keterangan' => 'A1',
+    ]);
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 501,
+        'keterangan' => 'A2',
+    ]);
+
+    $response = $this->postJson(
+        route('data.data-suplemen.getsuplementerdata', $this->suplemen->id),
+        [],
+        ['X-Requested-With' => 'XMLHttpRequest']
+    );
+
+    $response->assertStatus(200);
+    $data = collect($response->json('data'));
+
+    expect($batchCalls)->toBe(1)
+        ->and($sentIds)->toContain('500')
+        ->and($sentIds)->toContain('501')
+        ->and($data->pluck('penduduk.nama'))->toContain('Penduduk Gabungan 1')
+        ->and($data->pluck('penduduk.nama'))->toContain('Penduduk Gabungan 2');
+});
+
+test('editDetail menampilkan view gabungan saat database gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
+            'data' => [
+                [
+                    'id' => 99,
+                    'attributes' => [
+                        'nama' => 'Penduduk Gabungan Edit',
+                        'nik' => '1234567890123456',
+                        'sex' => 1,
+                        'config' => ['nama_desa' => 'Desa Edit'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['total' => 1]],
+        ], 200),
+    ]);
+
+    $terdata = SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Anggota gabungan',
+    ]);
+
+    $response = $this->get(route('data.data-suplemen.editdetail', [$terdata->id, $this->suplemen->id]));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.gabungan.edit_detail');
+    $response->assertViewHas('isDatabaseGabungan', true);
+    $response->assertSee('Penduduk Gabungan Edit');
+    $response->assertSee('sync-penduduk-opendk');
+    $response->assertSee('filter[kode_desa]');
+});
+
+test('editDetail menampilkan view lokal saat database gabungan tidak aktif', function () {
+    $penduduk = Penduduk::factory()->create(['nama' => 'Anggota Lokal Edit']);
+    $terdata = SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Anggota lokal',
+    ]);
+
+    $response = $this->get(route('data.data-suplemen.editdetail', [$terdata->id, $this->suplemen->id]));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('data.data_suplemen.edit_detail');
+    $response->assertViewHas('isDatabaseGabungan', false);
+});
+
+test('updateDetail memperbarui anggota gabungan saat gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $terdata = SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Keterangan awal',
+    ]);
+
+    $response = $this->put(route('data.data-suplemen.updatedetail', $terdata->id), [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 100,
+        'keterangan' => 'Keterangan diubah',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil diubah!');
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'id' => $terdata->id,
+        'penduduk_id' => null,
+        'penduduk_id_gabungan' => 100,
+        'keterangan' => 'Keterangan diubah',
+    ]);
+});
+
+test('destroyDetail menghapus anggota saat gabungan aktif', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $terdata = SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Anggota gabungan',
+    ]);
+
+    $response = $this->delete(route('data.data-suplemen.destroydetail', [$terdata->id, $this->suplemen->id]));
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+    $response->assertSessionHas('success', 'Anggota Suplemen berhasil dihapus!');
+
+    $this->assertDatabaseMissing('das_suplemen_terdata', ['id' => $terdata->id]);
+});

--- a/tests/Feature/Data/SuplemenGabunganTest.php
+++ b/tests/Feature/Data/SuplemenGabunganTest.php
@@ -32,6 +32,7 @@
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\CompleteProfile;
 use App\Http\Middleware\GlobalShareMiddleware;
+use App\Models\DataDesa;
 use App\Models\Penduduk;
 use App\Models\SettingAplikasi;
 use App\Models\Suplemen;
@@ -147,6 +148,7 @@ test('storeDetail menyimpan penduduk dari database gabungan saat gabungan aktif'
 
     $response = $this->post(route('data.data-suplemen.storedetail'), [
         'suplemen_id' => $this->suplemen->id,
+        'desa_id' => '3301010001',
         'penduduk_id_gabungan' => 99,
         'keterangan' => 'Anggota dari gabungan',
     ]);
@@ -158,6 +160,7 @@ test('storeDetail menyimpan penduduk dari database gabungan saat gabungan aktif'
         'suplemen_id' => $this->suplemen->id,
         'penduduk_id' => null,
         'penduduk_id_gabungan' => 99,
+        'desa_id' => '3301010001',
         'keterangan' => 'Anggota dari gabungan',
     ]);
 });
@@ -167,6 +170,7 @@ test('storeDetail menyimpan penduduk lokal saat database gabungan tidak aktif', 
 
     $response = $this->post(route('data.data-suplemen.storedetail'), [
         'suplemen_id' => $this->suplemen->id,
+        'desa_id' => $penduduk->desa_id,
         'penduduk_id' => $penduduk->id,
         'keterangan' => 'Anggota lokal',
     ]);
@@ -178,6 +182,7 @@ test('storeDetail menyimpan penduduk lokal saat database gabungan tidak aktif', 
         'suplemen_id' => $this->suplemen->id,
         'penduduk_id' => $penduduk->id,
         'penduduk_id_gabungan' => null,
+        'desa_id' => $penduduk->desa_id,
     ]);
 });
 
@@ -186,6 +191,7 @@ test('storeDetail gagal ketika penduduk lokal dan gabungan keduanya diisi', func
 
     $response = $this->post(route('data.data-suplemen.storedetail'), [
         'suplemen_id' => $this->suplemen->id,
+        'desa_id' => $penduduk->desa_id,
         'penduduk_id' => $penduduk->id,
         'penduduk_id_gabungan' => 99,
     ]);
@@ -193,7 +199,18 @@ test('storeDetail gagal ketika penduduk lokal dan gabungan keduanya diisi', func
     $response->assertSessionHasErrors(['penduduk_id_gabungan']);
 });
 
-test('getDataSuplemenTerdata menggabungkan anggota lokal dan API database gabungan', function () {
+test('storeDetail gagal ketika desa_id tidak diisi', function () {
+    $penduduk = Penduduk::factory()->create();
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+    ]);
+
+    $response->assertSessionHasErrors(['desa_id']);
+});
+
+test('getDataSuplemenTerdata tidak menggabungkan anggota dari API database gabungan', function () {
     aktifkanDatabaseGabungan(true);
     fakeGabunganApi([
         'https://api.example.com/api/v1/opendk/suplemen-terdata-datatable/*' => Http::response([
@@ -221,6 +238,7 @@ test('getDataSuplemenTerdata menggabungkan anggota lokal dan API database gabung
     SuplemenTerdata::create([
         'suplemen_id' => $this->suplemen->id,
         'penduduk_id' => $penduduk->id,
+        'desa_id' => $penduduk->desa_id,
         'keterangan' => 'Anggota lokal',
     ]);
 
@@ -234,9 +252,9 @@ test('getDataSuplemenTerdata menggabungkan anggota lokal dan API database gabung
     $data = collect($response->json('data'));
 
     expect($data->pluck('keterangan'))->toContain('Anggota lokal')
-        ->and($data->pluck('keterangan'))->toContain('Terdata desa')
+        ->not->toContain('Terdata desa')
         ->and($data->pluck('penduduk.nama'))->toContain('Anggota Lokal')
-        ->and($data->pluck('penduduk.nama'))->toContain('Anggota Dari API');
+        ->not->toContain('Anggota Dari API');
 });
 
 test('getDataSuplemenTerdata menyelesaikan penduduk gabungan lokal dalam satu request batch', function () {
@@ -294,6 +312,167 @@ test('getDataSuplemenTerdata menyelesaikan penduduk gabungan lokal dalam satu re
         ->and($sentIds)->toContain('501')
         ->and($data->pluck('penduduk.nama'))->toContain('Penduduk Gabungan 1')
         ->and($data->pluck('penduduk.nama'))->toContain('Penduduk Gabungan 2');
+});
+
+test('getDataSuplemenTerdata mengabaikan item non-array pada respons batch', function () {
+    aktifkanDatabaseGabungan(true);
+
+    Http::fake([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
+            'data' => [
+                ['id' => 500, 'attributes' => ['nama' => 'Penduduk Gabungan 1', 'nik' => '123', 'sex' => 1]],
+                false,
+                null,
+            ],
+            'meta' => ['pagination' => ['total' => 3]],
+        ], 200),
+        'https://api.example.com/api/v1/opendk/suplemen-terdata-datatable/*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+        '*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+    ]);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 500,
+        'keterangan' => 'A1',
+    ]);
+
+    $response = $this->postJson(
+        route('data.data-suplemen.getsuplementerdata', $this->suplemen->id),
+        [],
+        ['X-Requested-With' => 'XMLHttpRequest']
+    );
+
+    $response->assertStatus(200);
+    $data = collect($response->json('data'));
+
+    expect($data->pluck('penduduk.nama'))->toContain('Penduduk Gabungan 1');
+});
+
+test('getDataSuplemenTerdata memfilter anggota lokal berdasarkan desa', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi();
+
+    $desaA = DataDesa::create(['desa_id' => '3301010001', 'nama' => 'Desa A']);
+    $desaB = DataDesa::create(['desa_id' => '3301010002', 'nama' => 'Desa B']);
+
+    $pendudukA = Penduduk::factory()->create(['desa_id' => $desaA->desa_id, 'nama' => 'Warga Desa A']);
+    $pendudukB = Penduduk::factory()->create(['desa_id' => $desaB->desa_id, 'nama' => 'Warga Desa B']);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $pendudukA->id,
+        'desa_id' => $pendudukA->desa_id,
+        'keterangan' => 'A',
+    ]);
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $pendudukB->id,
+        'desa_id' => $pendudukB->desa_id,
+        'keterangan' => 'B',
+    ]);
+
+    $response = $this->postJson(
+        route('data.data-suplemen.getsuplementerdata', $this->suplemen->id),
+        ['desa' => $desaA->desa_id],
+        ['X-Requested-With' => 'XMLHttpRequest']
+    );
+
+    $response->assertStatus(200);
+    $data = collect($response->json('data'));
+
+    expect($data->pluck('penduduk.nama'))->toContain('Warga Desa A')
+        ->not->toContain('Warga Desa B');
+});
+
+test('getDataSuplemenTerdata tanpa filter desa menampilkan semua anggota lokal', function () {
+    $desaA = DataDesa::create(['desa_id' => '3301010001', 'nama' => 'Desa A']);
+    $desaB = DataDesa::create(['desa_id' => '3301010002', 'nama' => 'Desa B']);
+
+    $pendudukA = Penduduk::factory()->create(['desa_id' => $desaA->desa_id, 'nama' => 'Warga Desa A']);
+    $pendudukB = Penduduk::factory()->create(['desa_id' => $desaB->desa_id, 'nama' => 'Warga Desa B']);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $pendudukA->id,
+        'desa_id' => $pendudukA->desa_id,
+    ]);
+    SuplemenTerdata::create([
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $pendudukB->id,
+        'desa_id' => $pendudukB->desa_id,
+    ]);
+
+    $response = $this->postJson(
+        route('data.data-suplemen.getsuplementerdata', $this->suplemen->id),
+        ['desa' => 'Semua'],
+        ['X-Requested-With' => 'XMLHttpRequest']
+    );
+
+    $response->assertStatus(200);
+    $data = collect($response->json('data'));
+
+    expect($data->pluck('penduduk.nama'))->toContain('Warga Desa A')
+        ->toContain('Warga Desa B');
+});
+
+test('storeDetail menyimpan desa_id dari penduduk database gabungan', function () {
+    aktifkanDatabaseGabungan(true);
+    fakeGabunganApi([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
+            'data' => [
+                [
+                    'id' => 99,
+                    'attributes' => [
+                        'nama' => 'Penduduk Gabungan',
+                        'nik' => '123',
+                        'sex' => 1,
+                        'config' => ['kode_desa' => '3301010001', 'nama_desa' => 'Desa API'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['total' => 1]],
+        ], 200),
+    ]);
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'desa_id' => '3301010001',
+        'penduduk_id_gabungan' => 99,
+        'keterangan' => 'Anggota dari gabungan',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id_gabungan' => 99,
+        'desa_id' => '3301010001',
+    ]);
+});
+
+test('storeDetail menyimpan desa_id dari penduduk lokal', function () {
+    $penduduk = Penduduk::factory()->create(['desa_id' => '3301010003', 'nama' => 'Warga Lokal']);
+
+    $response = $this->post(route('data.data-suplemen.storedetail'), [
+        'suplemen_id' => $this->suplemen->id,
+        'desa_id' => $penduduk->desa_id,
+        'penduduk_id' => $penduduk->id,
+        'keterangan' => 'Anggota lokal',
+    ]);
+
+    $response->assertRedirect(route('data.data-suplemen.show', $this->suplemen->id));
+
+    $this->assertDatabaseHas('das_suplemen_terdata', [
+        'suplemen_id' => $this->suplemen->id,
+        'penduduk_id' => $penduduk->id,
+        'desa_id' => '3301010003',
+    ]);
 });
 
 test('editDetail menampilkan view gabungan saat database gabungan aktif', function () {
@@ -358,6 +537,7 @@ test('updateDetail memperbarui anggota gabungan saat gabungan aktif', function (
 
     $response = $this->put(route('data.data-suplemen.updatedetail', $terdata->id), [
         'suplemen_id' => $this->suplemen->id,
+        'desa_id' => '3301010001',
         'penduduk_id_gabungan' => 100,
         'keterangan' => 'Keterangan diubah',
     ]);

--- a/tests/Feature/SuplemenExportTest.php
+++ b/tests/Feature/SuplemenExportTest.php
@@ -2,11 +2,14 @@
 
 use App\Exports\ExportSuplemen;
 use App\Exports\ExportSuplemenTerdata;
+use App\Exports\ExportSuplemenTerdataGabungan;
 use App\Models\DataDesa;
 use App\Models\Penduduk;
 use App\Models\Suplemen;
 use App\Models\SuplemenTerdata;
+use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Http;
 use Maatwebsite\Excel\Facades\Excel;
 
 uses(DatabaseTransactions::class);
@@ -227,17 +230,17 @@ test('export suplemen terdata by id', function () {
     // Arrange: Buat data suplemen dan terdata
     Suplemen::query()->delete();
     SuplemenTerdata::query()->delete();
-    
+
     $desa = DataDesa::factory()->create();
     $penduduk = Penduduk::factory()->create(['desa_id' => $desa->desa_id]);
-    
+
     $suplemen = Suplemen::create([
         'nama' => 'Test Suplemen Terdata',
         'slug' => 'test-suplemen-terdata',
         'sasaran' => 1,
         'keterangan' => 'Test Keterangan'
     ]);
-    
+
     SuplemenTerdata::create([
         'suplemen_id' => $suplemen->id,
         'penduduk_id' => $penduduk->id,
@@ -266,23 +269,118 @@ test('export suplemen terdata by id with invalid id returns empty', function () 
     expect($collection)->toHaveCount(0);
 });
 
+test('export suplemen terdata with gabungan resolver fills penduduk relation', function () {
+    Suplemen::query()->delete();
+    SuplemenTerdata::query()->delete();
+
+    Http::fake([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
+            'data' => [
+                [
+                    'id' => 500,
+                    'attributes' => [
+                        'nama' => 'Penduduk Dari API',
+                        'nik' => '1234567890123456',
+                        'sex' => 1,
+                        'config' => ['kode_desa' => '3301010001', 'nama_desa' => 'Desa API'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['total' => 1]],
+        ], 200),
+    ]);
+
+    SettingAplikasi::updateOrCreate(['key' => 'api_server_database_gabungan'], ['value' => 'https://api.example.com']);
+    SettingAplikasi::updateOrCreate(['key' => 'api_key_database_gabungan'], ['value' => 'test-api-key']);
+
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Gabungan',
+        'slug' => 'suplemen-gabungan',
+        'sasaran' => 1,
+        'keterangan' => 'Test',
+    ]);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $suplemen->id,
+        'penduduk_id_gabungan' => 500,
+        'desa_id' => '3301010001',
+        'keterangan' => 'A1',
+    ]);
+
+    $export = new ExportSuplemenTerdataGabungan($suplemen->id, [], [500]);
+
+    $collection = $export->collection();
+
+    expect($collection)->toHaveCount(1)
+        ->and($collection->first()->penduduk_id_gabungan)->toBe(500)
+        ->and($collection->first()->desa_id)->toBe('3301010001')
+        ->and($collection->first()->penduduk)->not->toBeNull()
+        ->and($collection->first()->penduduk->nama)->toBe('Penduduk Dari API');
+});
+
+test('export suplemen terdata excel calls gabungan api when gabungan active', function () {
+    SettingAplikasi::updateOrCreate(['key' => 'sinkronisasi_database_gabungan'], ['value' => '1']);
+    SettingAplikasi::updateOrCreate(['key' => 'api_server_database_gabungan'], ['value' => 'https://api.example.com']);
+    SettingAplikasi::updateOrCreate(['key' => 'api_key_database_gabungan'], ['value' => 'test-api-key']);
+
+    Http::fake([
+        'https://api.example.com/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
+            'data' => [
+                [
+                    'id' => 500,
+                    'attributes' => [
+                        'nama' => 'Penduduk API Export',
+                        'nik' => '1234567890123456',
+                        'sex' => 1,
+                        'config' => ['kode_desa' => '3301010001', 'nama_desa' => 'Desa API'],
+                    ],
+                ],
+            ],
+            'meta' => ['pagination' => ['total' => 1]],
+        ], 200),
+        '*' => Http::response([
+            'data' => [],
+            'meta' => ['pagination' => ['total' => 0]],
+        ], 200),
+    ]);
+
+    $suplemen = Suplemen::create([
+        'nama' => 'Suplemen Gabungan Export',
+        'slug' => 'suplemen-gabungan-export',
+        'sasaran' => 1,
+        'keterangan' => 'Test',
+    ]);
+
+    SuplemenTerdata::create([
+        'suplemen_id' => $suplemen->id,
+        'penduduk_id_gabungan' => 500,
+        'desa_id' => '3301010001',
+        'keterangan' => 'A1',
+    ]);
+
+    $response = $this->get("/data/data-suplemen/export-terdata-excel/{$suplemen->id}");
+
+    $response->assertSuccessful();
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'api/v1/opendk/sync-penduduk-opendk'));
+});
+
 test('export suplemen terdata by id with multiple terdata', function () {
     // Arrange: Buat data suplemen dengan multiple terdata
     Suplemen::query()->delete();
     SuplemenTerdata::query()->delete();
-    
+
     $desa = DataDesa::factory()->create();
     $penduduk1 = Penduduk::factory()->create(['desa_id' => $desa->desa_id, 'nama' => 'Penduduk 1']);
     $penduduk2 = Penduduk::factory()->create(['desa_id' => $desa->desa_id, 'nama' => 'Penduduk 2']);
     $penduduk3 = Penduduk::factory()->create(['desa_id' => $desa->desa_id, 'nama' => 'Penduduk 3']);
-    
+
     $suplemen = Suplemen::create([
         'nama' => 'Test Suplemen Multiple',
         'slug' => 'test-suplemen-multiple',
         'sasaran' => 1,
         'keterangan' => 'Test Keterangan'
     ]);
-    
+
     SuplemenTerdata::create([
         'suplemen_id' => $suplemen->id,
         'penduduk_id' => $penduduk1->id,

--- a/tests/Feature/SuplemenExportTest.php
+++ b/tests/Feature/SuplemenExportTest.php
@@ -5,9 +5,9 @@ use App\Exports\ExportSuplemenTerdata;
 use App\Exports\ExportSuplemenTerdataGabungan;
 use App\Models\DataDesa;
 use App\Models\Penduduk;
+use App\Models\SettingAplikasi;
 use App\Models\Suplemen;
 use App\Models\SuplemenTerdata;
-use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Http;
 use Maatwebsite\Excel\Facades\Excel;
@@ -300,12 +300,15 @@ test('export suplemen terdata with gabungan resolver fills penduduk relation', f
         'keterangan' => 'Test',
     ]);
 
-    SuplemenTerdata::create([
+    $terdata = SuplemenTerdata::create([
         'suplemen_id' => $suplemen->id,
         'penduduk_id_gabungan' => 500,
         'desa_id' => '3301010001',
         'keterangan' => 'A1',
     ]);
+
+    expect(SuplemenTerdata::count())->toBe(1)
+        ->and(SuplemenTerdata::first()->penduduk_id_gabungan)->toBe(500);
 
     $export = new ExportSuplemenTerdataGabungan($suplemen->id, [], [500]);
 

--- a/tests/Unit/Services/PendudukServiceTest.php
+++ b/tests/Unit/Services/PendudukServiceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use App\Services\PendudukService;
 use App\Models\Penduduk;
 use App\Models\SettingAplikasi;
+use App\Services\PendudukService;
 use Illuminate\Support\Facades\Http;
 
 // Seed required settings for BaseApiService constructor
@@ -258,6 +258,37 @@ it('returns null when API returns empty', function () {
     $result = $service->detailPenduduk(1);
 
     expect($result)->toBeNull();
+});
+
+it('can fetch multiple penduduk from gabungan by ids', function () {
+    $sentParams = null;
+
+    Http::fake([
+        '*/api/v1/opendk/sync-penduduk-opendk*' => function (\Illuminate\Http\Client\Request $request) use (&$sentParams) {
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $sentParams);
+
+            return Http::response([
+                'data' => [
+                    ['id' => 500, 'attributes' => ['nama' => 'John Doe', 'nik' => '1234567890123456']],
+                    ['id' => 501, 'attributes' => ['nama' => 'Jane Doe', 'nik' => '1234567890123457']],
+                ],
+            ], 200);
+        },
+    ]);
+
+    $service = new PendudukService();
+    $result = $service->pendudukGabunganByIds([500, 501]);
+
+    expect($result)->toHaveCount(2);
+    expect($result->pluck('id'))->toContain(500);
+    expect($result->pluck('id'))->toContain(501);
+    expect($sentParams['filter']['id_penduduk'])->toBe(['500', '501']);
+});
+
+it('returns empty collection when gabungan ids empty', function () {
+    $service = new PendudukService();
+
+    expect($service->pendudukGabunganByIds([]))->toHaveCount(0);
 });
 
 it('can apply filters to jumlah penduduk', function () {


### PR DESCRIPTION
## Description

Pada kondisi **database gabungan aktif**, halaman tambah/ubah anggota suplemen tidak menampilkan daftar penduduk & keluarga (issue #1731). Penyebabnya: list penduduk diambil dari tabel lokal `das_penduduk` yang kosong pada mode gabungan, dan pengelolaan anggota sempat diblokir karena `penduduk_id` berelasi (FK) ke `das_penduduk` sedangkan data penduduk sebenarnya ada di database gabungan.

Solusi pada PR ini: daftar penduduk/keluarga dimuat **langsung dari API database gabungan** (select2 server-side), dan anggota suplemen disimpan dengan kolom baru `penduduk_id_gabungan` yang tidak ber-FK ke `das_penduduk` — sehingga pengelolaan anggota (tambah/ubah/hapus) kembali berfungsi saat mode gabungan aktif.

## Depedency

https://github.com/OpenSID/API-Database-Gabungan/pull/462

### Changes made:

1. **Migration**: Menambah kolom `penduduk_id_gabungan` (nullable) dan mengubah `penduduk_id` menjadi nullable pada `das_suplemen_terdata`.
2. **Model**: `SuplemenTerdata` menambahkan `penduduk_id_gabungan` ke `$fillable`.
3. **FormRequest**: Membuat `SuplemenRequest` (validasi `store`/`update` suplemen) dan `SuplemenTerdataRequest` (aturan *hanya salah satu sumber*: `penduduk_id` lokal ATAU `penduduk_id_gabungan`, tidak boleh kosong keduanya / terisi keduanya).
4. **Controller `SuplemenController`**:
   - `show()`, `createDetail()`, `editDetail()` menampilkan view terpisah untuk mode gabungan.
   - `storeDetail()` / `updateDetail()` menormalisasi sumber penduduk (lokal vs gabungan) agar tidak tersimpan keduanya.
   - `getDataSuplemenTerdata()` menggabungkan anggota lokal dengan anggota dari API gabungan (`suplemen-terdata-datatable/{id}`), resolusi penduduk anggota lokal dilakukan **batch** via `PendudukService::pendudukGabunganByIds()` (filter `id_penduduk` array — satu request, bukan N+1).
   - Menambahkan type hint parameter & return type (`View`, `RedirectResponse`, `JsonResponse`, `BinaryFileResponse`) agar konsisten dengan modul lain.
5. **Service**: `PendudukService::pendudukGabunganByIds(array $ids)` mengambil beberapa penduduk sekaligus dari API gabungan.
6. **Views gabungan** (baru):
   - `data_suplemen/gabungan/show.blade.php` — daftar anggota gabungan + filter desa + tombol Tambah.
   - `data_suplemen/gabungan/create_detail.blade.php` & `edit_detail.blade.php` — pilihan desa via fragment `list-desa`, pilihan penduduk/keluarga via **select2 AJAX** ke `sync-penduduk-opendk` (dengan filter `kode_desa`, `status_dasar`, dan `kk_level=1` bila sasaran Keluarga/KK); edit juga mengizinkan mengganti desa & penduduk.
   - `form_detail.blade.php` — nama field penduduk dinamis (`penduduk_id_gabungan` pada mode gabungan).
7. **Tests**: `SuplemenControllerRequestTest` (baru), `SuplemenGabunganTest` (baru/diperluas), penambahan unit test `PendudukServiceTest` pada `pendudukGabunganByIds`.

### Reason for change:

- **Point 1**: Pada mode gabungan, data penduduk/keluarga berada di database gabungan (diakses via API), bukan di tabel lokal `das_penduduk`. Menambah anggota yang merujuk `penduduk_id` lokal akan gagal FK atau menghasilkan data kosong.
- **Point 2**: Kolom baru `penduduk_id_gabungan` memutus ketergantungan FK ke `das_penduduk`, sehingga anggota bisa disimpan dengan referensi penduduk dari database gabungan — menyelesaikan issue #1731.
- **Point 3**: Aturan *hanya salah satu sumber* + normalisasi server-side menjamin integritas data: satu anggota hanya merujuk satu sumber penduduk (lokal atau gabungan).

### Impact of change:

✅ **List penduduk & keluarga tampil** pada tambah/ubah anggota saat database gabungan aktif (diambil dari API gabungan).
✅ **Tambah/Ubah/Hapus anggota mengizinkan gabungan**: pengguna bisa mengganti desa & penduduk anggota (select2 server-side), filter kepala keluarga untuk sasaran KK.
✅ **Halaman show menggabungkan** anggota lokal dengan data terdata dari API gabungan.
✅ **Performa**: resolusi penduduk anggota dilakukan satu request batch (`filter[id_penduduk]` array), bukan request per anggota.
✅ **Integritas data**: kolom `penduduk_id` local | `penduduk_id_gabungan` tidak pernah terisi bersamaan.

## Related Issue

- Closes #1731 — [Menambah anggota penduduk untuk data suplemen tidak menampilkan list penduduk & keluarga pada kondisi database gabungan aktif](https://github.com/OpenSID/OpenDK/issues/1731)

## Steps to Reproduce

### Before fix (problem):
1. Aktifkan `sinkronisasi_database_gabungan = 1` pada pengaturan.
2. Buka menu **Kependudukan → Data Suplemen → Tambah Anggota**.
3. ❌ Daftar penduduk/keluarga tidak tampil / tidak dapat disimpan (data hanya di database lokal `das_penduduk`).

### After fix (solution):
1. Aktifkan `sinkronisasi_database_gabungan = 1`.
2. Buka menu **Kependudukan → Data Suplemen → Tambah Anggota** (mode gabungan).
3. Pilih desa pada dropdown, lalu pilih penduduk/keluarga dari dropdown select2 (data dari API database gabungan; filter `kk_level=1` otomatis untuk sasaran Keluarga/KK).
4. Isi keterangan & simpan.
5. ✅ Anggota tersimpan dengan `penduduk_id_gabungan` dan tampil pada halaman detail (show).

### Testing on related features:
- Data Suplemen (list/CRUD dasar) — ✅ tetap berfungsi (mode non-gabungan)
- Tambah/Ubah/Hapus anggota — ✅ berfungsi di mode lokal & gabungan
- Export Excel suplemen & suplemen terdata — ✅ tidak terpengaruh

## Checklist

- [x] Saya telah mematuhi [aturan penulisan script](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [ ] Saya telah mengikuti [proses review pull request](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] Saya telah membuat unit/integration test untuk memverifikasi perbaikan
- [ ] Pengujian manual telah dilakukan di environment development
- [ ] Tidak ada console errors atau warnings
- [ ] Kode telah direview oleh [minimal 1 orang]

## Technical Details

### Technical Explanation

**Skema data** — migration `2026_09_07_000001_add_penduduk_id_gabungan_to_suplemen_terdata_table.php`:

```php
Schema::table('das_suplemen_terdata', function (Blueprint $table) {
    $table->unsignedBigInteger('penduduk_id_gabungan')->nullable()->after('penduduk_id');
    $table->unsignedInteger('penduduk_id')->nullable()->change();
});
```

**Validasi tepat-satu sumber** — `SuplemenTerdataRequest::withValidator()`:

```php
$validator->after(function ($validator) {
    $hasLocal = $this->filled('penduduk_id');
    $hasGabungan = $this->filled('penduduk_id_gabungan');

    if (! $hasLocal && ! $hasGabungan) {
        $validator->errors()->add('penduduk_id', 'isian warga atau penduduk wajib diisi');
    }
    if ($hasLocal && $hasGabungan) {
        $validator->errors()->add('penduduk_id_gabungan', 'hanya boleh memilih salah satu, penduduk lokal atau penduduk database gabungan');
    }
});
```

**Alur ambil penduduk gabungan**:
- Form `create_detail`/`edit_detail` (gabungan) memakai select2 AJAX ke `{api_server_database_gabungan}/api/v1/opendk/sync-penduduk-opendk` dengan parameter `filter[kode_kecamatan]`, `filter[kode_desa]` (desa terpilih), `filter[status_dasar]=1`, `page[size]`, dan `filter[kk_level]=1` saat sasaran bukan 1; respons JSON:API dipetakan di `processResults`.
- `getDataSuplemenTerdata()` (datatable show) menggabungkan baris lokal (`das_suplemen_terdata`) dengan baris dari API `suplemen-terdata-datatable/{id}`; penduduk lokal-gabungan di-resolve batch via `PendudukService::pendudukGabunganByIds()` menggunakan `filter[id_penduduk]` berupa array.
- Catatan select2 fork di project ini: method `select2('enable', bool)` hanya mengubah `prop('disabled')`; enable/disable container dikerjakan lewat `instance._syncAttributes()` agar class `select2-container--disabled` & status `options.disabled` tersinkron.

**Flag gabungan** di view disuplai dari `isDatabaseGabungan()` (setting `sinkronisasi_database_gabungan`).

### Configuration changes

Tidak ada perubahan konfigurasi baru; memanfaatkan setting yang sudah ada:
- `sinkronisasi_database_gabungan`
- `api_server_database_gabungan`
- `api_key_database_gabungan`

### Dependencies added

Tidak ada dependensi baru.

## Testing

### Manual Testing

- [ ] Mode non-gabungan: tambah/ubah anggota suplemen masih memilih penduduk lokal dan tersimpan di `penduduk_id`
- [ ] Mode gabungan: tambah anggota — pilih desa, pilih penduduk/keluarga dari select2 (data API), simpan → tersimpan di `penduduk_id_gabungan`
- [ ] Mode gabungan: ubah anggota — ganti desa/penduduk serta keterangan, simpan
- [ ] Mode gabungan: hapus anggota
- [ ] Mode gabungan: halaman show menampilkan anggota lokal + anggota dari API gabungan
- [ ] Validasi error saat tidak memilih penduduk, dan saat mengisi keduanya (lokal + gabungan)
- [ ] Regression testing — fitur Data Suplemen lain (list, CRUD, export) tidak rusak

### Automated Testing

- [ ] Integration Test — `tests/Feature/Data/SuplemenGabunganTest.php` (13 test: view gabungan/lokal, simpan anggota gabungan/lokal, aturan tepat-satu sumber, merge datatable, batch resolusi, update/destroy gabungan)
- [ ] Integration Test — `tests/Feature/Data/SuplemenControllerRequestTest.php` (7 test: store/update suplemen, storeDetail/updateDetail dengan validasi)
- [ ] Unit Test — `tests/Unit/Services/PendudukServiceTest.php` (`pendudukGabunganByIds` mengirim `filter[id_penduduk]` array & mengembalikan koleksi)
- [ ] Regression — `tests/Feature/KependudukanDataTablesPostTest.php`, `tests/Feature/SuplemenExportTest.php`, `tests/Unit/Models/PendudukTest.php`, `tests/Arch` (total 85 test lolos)

## Screenshots / Video

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8f849a95-cad0-429f-9b89-a5ba86889254" />


### Before:

Daftar penduduk/keluarga tidak tampil saat menambah anggota suplemen pada mode database gabungan.

### After:

Dropdown desa + pilihan penduduk/keluarga (select2 dari API database gabungan) tampil dan dapat disimpan.

## Breaking Changes

Tidak ada breaking change fungsional. Perlu menjalankan migration **`php artisan migrate`** untuk menambah kolom `penduduk_id_gabungan` dan mengubah `penduduk_id` menjadi nullable (keduanya backward-compatible; kolom baru nullable).

## Migration Guide

1. Jalankan `php artisan migrate` pada environment target (CI/produksi).
2. Tidak ada perubahan data yang diperlukan — data `das_suplemen_terdata` lama tetap valid.

## References

- [OpenDK Repo](https://github.com/OpenSID/opendk)
- [Issue #1731](https://github.com/OpenSID/OpenDK/issues/1731)

---

**Additional notes:** Branch `fix/suplemen_gabungan` menuju `rilis-dev`. Total 13 file diubah (+1622/−128), termasuk 3 view gabungan baru dan 2 form request baru. Testing otomatis: 85 test lolos (feature gabungan + request + service + regresi).