### PR TITLE
Fix : Berkas download laporan penduduk tidak ditemukan saat Database Gabungan aktif

### DIFF
--- a/resources/views/data/laporan-penduduk/gabungan/index.blade.php
+++ b/resources/views/data/laporan-penduduk/gabungan/index.blade.php
@@ -99,7 +99,7 @@
                             const _url = data.attributes.path === undefined ?
                                 `{{ route('data.laporan-penduduk.export-excel.by-id', ['data' => '__DATA__']) }}`
                                 .replace('__DATA__', jsonData) :
-                                `asset('storage/laporan_penduduk')/${data.nama_file}`
+                                data.attributes.path
                             const _disabled = data.attributes.path === undefined ? 'disabled' : ''
 
                             return `<a href="${_url}" title="Unduh" data-button="download" target="_blank">


### PR DESCRIPTION
## Description

Ketika **Database Gabungan** aktif, berkas download laporan penduduk di halaman `data/laporan-penduduk/gabungan` gagal ditemukan karena URL download dibangun dari path lokal `asset('storage/laporan_penduduk')/nama_file`, padahal berkas sebenarnya berada di server API Database Gabungan (remote). Fix ini mengubah URL download agar menggunakan `data.attributes.path` yang dikembalikan oleh API Database Gabungan, sehingga tautan mengarah ke berkas yang benar.

### Changes made:

1. **[Bug Fix]**: Mengganti URL download pada `resources/views/data/laporan-penduduk/gabungan/index.blade.php` dari `asset('storage/laporan_penduduk')/${data.nama_file}` menjadi `data.attributes.path` ketika `attributes.path` tersedia di respons API.

### Reason for change:

- **Poin 1**: Saat Database Gabungan aktif, berkas laporan penduduk disimpan dan dilayani oleh server API Database Gabungan (remote), bukan di storage lokal OpenDK, sehingga path lokal `storage/laporan_penduduk` selalu menunjuk ke berkas yang tidak ada → muncul error "berkas tidak ditemukan".
- **Poin 2**: API Database Gabungan sudah menyediakan atribut `path` pada respons-nya yang berisi URL langsung ke berkas; perubahan pada sisi API dilandaskan pada PR [OpenSID/API-Database-Gabungan#463](https://github.com/OpenSID/API-Database-Gabungan/pull/463).
- **Poin 3**: Dengan memakai `data.attributes.path` langsung, tautan unduh mengarah ke lokasi berkas yang benar tanpa perlu menebak-nembak lokasi penyimpanan.

### Impact of change:

✅ **Tautan unduh valid**: URL kini berasal dari respons API Database Gabungan, bukan path lokal yang keliru.
✅ **Perilaku lama dipertahankan**: Saat `attributes.path` tidak tersedia (`undefined`), fallback tetap memakai route internal `data.laporan-penduduk.export-excel.by-id`, jadi mode non-gabungan tidak terpengaruh.
✅ **Selaras dengan API**: Konsisten dengan perbaikan sisi API sehingga ekosistem berfungsi menyeluruh.

## Related Issue

- Solution for fix related to issue #[1732](https://github.com/OpenSID/OpenDK/issues/1732)

## Steps to Reproduce

### Before fix (problem):
1. Aktifkan Database Gabungan di aplikasi OpenDK.
2. Buka menu Laporan Penduduk → tab Gabungan.
3. Klik tombol **download** pada salah satu baris laporan.
4. ❌ Berkas tidak ditemukan / halaman error karena URL mengarah ke `storage/laporan_penduduk/...` yang tidak ada di server OpenDK.

### After fix (solution):
1. Aktifkan Database Gabungan di aplikasi OpenDK.
2. Buka menu Laporan Penduduk → tab Gabungan.
3. Klik tombol **download** pada salah satu baris laporan.
4. ✅ Berkas berhasil diunduh dari URL `data.attributes.path` yang disediakan API Database Gabungan.

### Testing on related features:
- Laporan Penduduk — data gabungan (Database Gabungan aktif) ✅
- Laporan Penduduk — data lokal (Database Gabungan non-aktif) ✅

## Checklist
- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [ ] I have created [unit test/integration test] to verify the fix
- [x] Manual testing has been done in development environment
- [ ] No console errors or warnings
- [ ] Code has been reviewed by [at least 1 person]

## Technical Details

### Technical Explanation

Pada tampilan `resources/views/data/laporan-penduduk/gabungan/index.blade.php`, konstruksi URL download memakai ternary dengan fallback ke route export internal:

```js
const _url = data.attributes.path === undefined ?
    `{{ route('data.laporan-penduduk.export-excel.by-id', ['data' => '__DATA__']) }}`
    .replace('__DATA__', jsonData) :
    data.attributes.path
```

- **Sebelum fix**: ketika `attributes.path` terisi (Database Gabungan aktif), URL dibangun ulang dari path lokal `asset('storage/laporan_penduduk')/${data.nama_file}`, sehingga mengabaikan `path` dari API dan menunjuk ke berkas yang tidak ada di server OpenDK.
- **Setelah fix**: `data.attributes.path` (URL berkas remote dari API) dipakai langsung sebagai href tautan unduh.

### Configuration changes
Tidak ada perubahan konfigurasi.

### Dependencies added
- **Dependency PR**: [OpenSID/API-Database-Gabungan#463](https://github.com/OpenSID/API-Database-Gabungan/pull/463) — perbaikan sisi API yang meyediakan/membersihkan atribut `path` pada respons laporan penduduk gabungan. PR ini **bergantung** pada PR tersebut untuk berfungsi secara end-to-end.

## Testing

### Manual Testing
- [x] Download laporan penduduk pada tab Gabungan dengan Database Gabungan aktif
- [x] Download laporan penduduk pada mode Database Gabungan non-aktif (regresi, fallback route internal)
- [x] Regression Testing — pastikan fitur laporan penduduk lain tidak rusak

## Screenshots / Video


https://github.com/user-attachments/assets/7c4d2e1b-4c19-4503-af60-4e21b401aedc



## Breaking Changes

None

## Migration Guide

Not required

## References
- [Issue OpenDK #1732](https://github.com/OpenSID/OpenDK/issues/1732)
- [Dependency PR API-Database-Gabungan #463](https://github.com/OpenSID/API-Database-Gabungan/pull/463)
- [Route `data.laporan-penduduk.export-excel.by-id`](routes/web.php:638) → `LaporanPendudukController@exportExcelById` (`app/Http/Controllers/Data/LaporanPendudukController.php:212`)

---

**Additional notes:** PR ini harus digabung/rilis bersamaan dengan dependency-nya di [OpenSID/API-Database-Gabungan#463](https://github.com/OpenSID/API-Database-Gabungan/pull/463) agar download laporan penduduk berfungsi penuh saat Database Gabungan aktif.