### PR TITLE
Penyesuaian Pratinjau File PDF dan Gambar pada Menu Prosedur, Regulasi, dan Potensi

### DIFF
--- a/app/Http/Controllers/Informasi/PotensiController.php
+++ b/app/Http/Controllers/Informasi/PotensiController.php
@@ -31,11 +31,11 @@
 
 namespace App\Http\Controllers\Informasi;
 
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PotensiRequest;
 use App\Models\Potensi;
 use App\Models\TipePotensi;
 use App\Traits\HandlesFileUpload;
-use App\Http\Controllers\Controller;
-use App\Http\Requests\PotensiRequest;
 use Illuminate\Support\Facades\Log;
 use Yajra\DataTables\Facades\DataTables;
 
@@ -103,6 +103,10 @@ class PotensiController extends Controller
 
             $this->handleFileUpload($request, $input, 'file_gambar', 'potensi_kecamatan');
 
+            if ($request->hasFile('file_gambar')) {
+                $input['mime_type'] = $request->file('file_gambar')->getClientMimeType();
+            }
+
             Potensi::create($input);
         } catch (\Exception $e) {
             Log::error('Potensi creation failed', [
@@ -138,6 +142,10 @@ class PotensiController extends Controller
             $input = $request->all();
 
             $this->handleFileUpload($request, $input, 'file_gambar', 'potensi_kecamatan');
+
+            if ($request->hasFile('file_gambar')) {
+                $input['mime_type'] = $request->file('file_gambar')->getClientMimeType();
+            }
 
             $potensi->update($input);
         } catch (\Exception $e) {
@@ -175,25 +183,13 @@ class PotensiController extends Controller
     public function download(Potensi $potensi)
     {
         try {
-            $path = $potensi->file_gambar;
-            if (empty($path)) {
+            $filePath = $this->resolveSecureFilePath($potensi->file_gambar);
+
+            if (!$filePath) {
                 return back()->with('error', 'Dokumen potensi tidak ditemukan');
             }
 
-            if (file_exists(public_path($path))) {
-                return response()->download(public_path($path));
-            }
-
-            if (file_exists(base_path('public/' . $path))) {
-                return response()->download(base_path('public/' . $path));
-            }
-
-            $storagePath = storage_path('app/public/' . str_replace('storage/', '', $path));
-            if (file_exists($storagePath)) {
-                return response()->download($storagePath);
-            }
-            
-            return back()->with('error', 'Dokumen potensi tidak ditemukan');
+            return response()->download($filePath);
         } catch (\Exception $e) {
             Log::error('Potensi download failed', [
                 'error' => $e->getMessage(),

--- a/app/Http/Controllers/Informasi/ProsedurController.php
+++ b/app/Http/Controllers/Informasi/ProsedurController.php
@@ -31,12 +31,12 @@
 
 namespace App\Http\Controllers\Informasi;
 
-use App\Models\Prosedur;
-use Yajra\DataTables\DataTables;
-use App\Traits\HandlesFileUpload;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ProsedurRequest;
+use App\Models\Prosedur;
+use App\Traits\HandlesFileUpload;
 use Illuminate\Support\Facades\Log;
+use Yajra\DataTables\DataTables;
 
 class ProsedurController extends Controller
 {
@@ -98,7 +98,6 @@ class ProsedurController extends Controller
                 }
 
                 $data['download_url'] = auth()->user()->can('access.informasi.prosedur.export') ? route('informasi.prosedur.download', $row->id) : null;
-                $data['preview_url'] = auth()->user()->can('access.informasi.prosedur.view') ? route('informasi.prosedur.preview', $row->id) : null;
 
                 return view('forms.aksi', $data);
             })
@@ -196,7 +195,13 @@ class ProsedurController extends Controller
     public function download(Prosedur $prosedur)
     {
         try {
-            return response()->download($prosedur->file_prosedur);
+            $filePath = $this->resolveSecureFilePath($prosedur->file_prosedur);
+
+            if (!$filePath) {
+                return back()->with('error', 'Dokumen prosedur tidak ditemukan');
+            }
+
+            return response()->download($filePath);
         } catch (\Exception $e) {
             Log::error('Prosedur download failed', [
                 'error' => $e->getMessage(),
@@ -206,29 +211,5 @@ class ProsedurController extends Controller
 
             return back()->with('error', 'Dokumen prosedur tidak ditemukan');
         }
-    }
-
-    public function preview(Prosedur $prosedur)
-    {
-        $path = $prosedur->file_prosedur;
-
-        if (empty($path)) {
-            abort(404, 'File tidak ditemukan.');
-        }
-
-        if (file_exists(public_path($path))) {
-            return response()->file(public_path($path));
-        }
-
-        if (file_exists(base_path('public/' . $path))) {
-            return response()->file(base_path('public/' . $path));
-        }
-
-        $storagePath = storage_path('app/public/' . str_replace('storage/', '', $path));
-        if (file_exists($storagePath)) {
-            return response()->file($storagePath);
-        }
-
-        abort(404, 'File tidak ditemukan.');
     }
 }

--- a/app/Http/Controllers/Informasi/RegulasiController.php
+++ b/app/Http/Controllers/Informasi/RegulasiController.php
@@ -31,12 +31,12 @@
 
 namespace App\Http\Controllers\Informasi;
 
-use App\Models\Regulasi;
-use App\Traits\HandlesFileUpload;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\RegulasiRequest;
 use App\Http\Requests\RegulasiUpdateRequest;
+use App\Models\Regulasi;
 use App\Models\TipeRegulasi;
+use App\Traits\HandlesFileUpload;
 use Illuminate\Support\Facades\Log;
 use Yajra\DataTables\Facades\DataTables;
 
@@ -124,7 +124,6 @@ class RegulasiController extends Controller
             $input['profil_id'] = $this->profil->id;
             $this->handleFileUpload($request, $input, 'file_regulasi', 'regulasi');
 
-
             if ($request->hasFile('file_regulasi')) {
                 $input['mime_type'] = $request->file('file_regulasi')->getMimeType();
             }
@@ -167,7 +166,13 @@ class RegulasiController extends Controller
     public function download(Regulasi $regulasi)
     {
         try {
-            return response()->download($regulasi->file_regulasi);
+            $filePath = $this->resolveSecureFilePath($regulasi->file_regulasi);
+
+            if (!$filePath) {
+                return back()->with('error', 'Dokumen regulasi tidak ditemukan');
+            }
+
+            return response()->download($filePath);
         } catch (\Exception $e) {
             Log::error('Regulasi download failed', [
                 'error' => $e->getMessage(),

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -41,7 +41,6 @@ class SecurityHeaders
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return mixed
      */
     public function handle($request, Closure $next)
     {
@@ -51,8 +50,7 @@ class SecurityHeaders
         if (app()->environment('production')) {
             $localDomain = env('APP_URL', 'http://localhost');
             $urlDatabaseGabungan = config('setting.api_server_database_gabungan');
-            $response->headers->set('X-Content-Type-Options', 'nosniff');            
-            $response->headers->set('Content-Security-Policy', "default-src 'self';script-src 'self' https://pantau.opensid.my.id/ https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ https://cdnjs.cloudflare.com/ajax/libs/numeral.js/2.0.6/numeral.min.js https://website-widgets.pages.dev/dist/sienna.min.js platform.twitter.com unpkg.com 'unsafe-inline' 'unsafe-eval';style-src 'self' https://www.tiny.cloud/ http://www.tinymce.com/css/codepen.min.css https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ fonts.googleapis.com unpkg.com 'unsafe-inline';img-src 'self' * data:;font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ fonts.gstatic.com data:;connect-src 'self' ".$urlDatabaseGabungan." https://pantau.opensid.my.id/ ;media-src 'self';frame-src 'self' platform.twitter.com github.com *.youtube.com *.vimeo.com *.opensid.my.id;object-src 'none';base-uri 'self';report-uri");
+            $response->headers->set('Content-Security-Policy', "default-src 'self';script-src 'self' https://pantau.opensid.my.id/ https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ https://cdnjs.cloudflare.com/ajax/libs/numeral.js/2.0.6/numeral.min.js https://website-widgets.pages.dev/dist/sienna.min.js platform.twitter.com unpkg.com 'unsafe-inline' 'unsafe-eval';style-src 'self' https://www.tiny.cloud/ http://www.tinymce.com/css/codepen.min.css https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ fonts.googleapis.com unpkg.com 'unsafe-inline';img-src 'self' * data: blob:;font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/tinymce/ https://cdn.jsdelivr.net/npm/ fonts.gstatic.com data:;connect-src 'self' ".$urlDatabaseGabungan." https://pantau.opensid.my.id/ ;media-src 'self';frame-src 'self' blob: data: platform.twitter.com github.com *.youtube.com *.vimeo.com *.opensid.my.id;object-src 'self' blob:;frame-ancestors 'self';base-uri 'self';");
         }
 
         return $response;

--- a/app/Http/Requests/PotensiRequest.php
+++ b/app/Http/Requests/PotensiRequest.php
@@ -57,7 +57,7 @@ class PotensiRequest extends FormRequest
             'nama_potensi' => 'required|string|max:200',
             'deskripsi' => 'required|string',
             'lokasi' => 'required|string|max:200',
-            'file_gambar' => 'file|mimes:bmp,jpg,jpeg,gif,png' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:1024' : '') . '|valid_file',
+            'file_gambar' => 'file|mimes:bmp,jpg,jpeg,gif,png,pdf' . (\App\Services\FileUploadService::isLimitEnabled() ? '|max:2048' : '') . '|valid_file',
         ];
     }
 }

--- a/app/Models/Potensi.php
+++ b/app/Models/Potensi.php
@@ -41,13 +41,6 @@ class Potensi extends Model
 
     protected $table = 'das_potensi';
 
-    protected static function booted(): void
-    {
-        static::created(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
-        static::updated(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
-        static::deleted(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
-    }
-
     protected $fillable = [
         'kategori_id',
         'nama_potensi',
@@ -56,6 +49,7 @@ class Potensi extends Model
         'long',
         'lat',
         'file_gambar',
+        'mime_type',
     ];
 
     /**
@@ -70,5 +64,18 @@ class Potensi extends Model
     public function tipe()
     {
         return $this->hasOne(TipePotensi::class, 'id', 'kategori_id');
+    }
+
+    public function getIsPdfAttribute(): bool
+    {
+        return str_contains(strtolower($this->mime_type ?? ''), 'pdf')
+            || str_ends_with(strtolower($this->file_gambar ?? ''), '.pdf');
+    }
+
+    protected static function booted(): void
+    {
+        static::created(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
+        static::updated(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
+        static::deleted(fn (Potensi $potensi) => PotensiChanged::dispatch($potensi));
     }
 }

--- a/app/Models/Prosedur.php
+++ b/app/Models/Prosedur.php
@@ -32,15 +32,15 @@
 namespace App\Models;
 
 use App\Traits\HandlesResourceDeletion;
-use Illuminate\Database\Eloquent\Model;
 use Cviebrock\EloquentSluggable\Sluggable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Prosedur extends Model
 {
+    use HandlesResourceDeletion;
     use HasFactory;
     use Sluggable;
-    use HandlesResourceDeletion;
 
     protected $table = 'das_prosedur';
 
@@ -72,5 +72,9 @@ class Prosedur extends Model
         ];
     }
 
+    public function getIsPdfAttribute(): bool
+    {
+        return str_contains(strtolower($this->mime_type ?? ''), 'pdf')
+            || str_ends_with(strtolower($this->file_prosedur ?? ''), '.pdf');
+    }
 }
-

--- a/app/Models/Regulasi.php
+++ b/app/Models/Regulasi.php
@@ -41,13 +41,6 @@ class Regulasi extends Model
 
     protected $table = 'das_regulasi';
 
-    protected static function booted(): void
-    {
-        static::created(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
-        static::updated(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
-        static::deleted(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
-    }
-
     protected $fillable = [
         'kecamatan_id',
         'tipe_regulasi',
@@ -69,5 +62,18 @@ class Regulasi extends Model
     public function tipe()
     {
         return $this->hasOne(TipeRegulasi::class, 'id', 'tipe_regulasi');
+    }
+
+    public function getIsPdfAttribute(): bool
+    {
+        return str_contains(strtolower($this->mime_type ?? ''), 'pdf')
+            || str_ends_with(strtolower($this->file_regulasi ?? ''), '.pdf');
+    }
+
+    protected static function booted(): void
+    {
+        static::created(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
+        static::updated(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
+        static::deleted(fn (Regulasi $regulasi) => RegulasiChanged::dispatch($regulasi));
     }
 }

--- a/app/Traits/HandlesFileUpload.php
+++ b/app/Traits/HandlesFileUpload.php
@@ -36,7 +36,7 @@ use Illuminate\Http\UploadedFile;
 trait HandlesFileUpload
 {
     /**
-     * Daftar MIME types default yang diizinkan
+     * Daftar MIME types default yang diizinkan.
      */
     protected array $defaultAllowedMimes = [
         'image' => ['jpeg', 'png', 'jpg', 'gif', 'svg', 'webp'],
@@ -53,7 +53,9 @@ trait HandlesFileUpload
      * @param string $directory
      * @param bool $withDirectory
      * @param array $allowedMimes Optional list of allowed mime extensions
+     *
      * @return void
+     *
      * @throws \Illuminate\Validation\ValidationException
      */
     public function handleFileUpload($request, &$input, $field = 'file', $directory = 'uploads', $withDirectory = true, array $allowedMimes = [])
@@ -79,11 +81,44 @@ trait HandlesFileUpload
     }
 
     /**
+     * Resolve file path secara aman dan pastikan berada dalam direktori yang diizinkan (mencegah Path Traversal).
+     */
+    public function resolveSecureFilePath(?string $path): ?string
+    {
+        if (empty($path)) {
+            return null;
+        }
+
+        $candidates = [
+            public_path($path),
+            base_path('public/' . $path),
+            storage_path('app/public/' . str_replace('storage/', '', $path)),
+        ];
+
+        $allowedPublic = realpath(public_path());
+        $allowedStorage = realpath(storage_path('app/public'));
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                $real = realpath($candidate);
+                if ($real) {
+                    $isAllowedPublic = $allowedPublic && str_starts_with($real, $allowedPublic);
+                    $isAllowedStorage = $allowedStorage && str_starts_with($real, $allowedStorage);
+                    if ($isAllowedPublic || $isAllowedStorage) {
+                        return $real;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Validasi MIME type file.
      *
-     * @param UploadedFile $file
      * @param array $allowedMimes List of allowed extensions (e.g., ['jpg', 'png', 'pdf'])
-     * @return void
+     *
      * @throws \Illuminate\Validation\ValidationException
      */
     protected function validateMimeType(UploadedFile $file, array $allowedMimes): void
@@ -92,7 +127,7 @@ trait HandlesFileUpload
 
         if (!in_array($extension, $allowedMimes)) {
             throw \Illuminate\Validation\ValidationException::withMessages([
-                'file' => "Tipe file tidak diizinkan. Tipe yang diizinkan: " . implode(', ', $allowedMimes),
+                'file' => 'Tipe file tidak diizinkan. Tipe yang diizinkan: ' . implode(', ', $allowedMimes),
             ]);
         }
 
@@ -102,16 +137,13 @@ trait HandlesFileUpload
 
         if (!empty($allowedMimeTypes) && !in_array($mimeType, $allowedMimeTypes)) {
             throw \Illuminate\Validation\ValidationException::withMessages([
-                'file' => "MIME type file tidak valid. Pastikan file yang diupload sesuai dengan ekstensinya.",
+                'file' => 'MIME type file tidak valid. Pastikan file yang diupload sesuai dengan ekstensinya.',
             ]);
         }
     }
 
     /**
      * Generate nama file yang aman untuk penyimpanan.
-     *
-     * @param UploadedFile $file
-     * @return string
      */
     protected function generateSafeFileName(UploadedFile $file): string
     {
@@ -120,9 +152,6 @@ trait HandlesFileUpload
 
     /**
      * Convert extensions to MIME types.
-     *
-     * @param array $extensions
-     * @return array
      */
     protected function extensionsToMimeTypes(array $extensions): array
     {
@@ -158,7 +187,6 @@ trait HandlesFileUpload
      * Mendapatkan daftar MIME types berdasarkan kategori.
      *
      * @param string $category 'image', 'document', atau 'archive'
-     * @return array
      */
     protected function getAllowedMimesByCategory(string $category): array
     {

--- a/database/migrations/2026_09_07_000001_add_mime_type_to_das_potensi_table.php
+++ b/database/migrations/2026_09_07_000001_add_mime_type_to_das_potensi_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('das_potensi', function (Blueprint $table) {
+            if (!Schema::hasColumn('das_potensi', 'mime_type')) {
+                $table->string('mime_type', 50)->nullable()->after('file_gambar');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('das_potensi', function (Blueprint $table) {
+            if (Schema::hasColumn('das_potensi', 'mime_type')) {
+                $table->dropColumn('mime_type');
+            }
+        });
+    }
+};

--- a/helpers/general_helper.php
+++ b/helpers/general_helper.php
@@ -42,7 +42,7 @@ use Illuminate\Support\Facades\Storage;
 use voku\helper\AntiXSS;
 use willvincent\Feeds\Facades\FeedsFacade;
 
-/**
+/*
  * Parsing url image dari rss feed description
  *
  * @param  string  $content
@@ -60,9 +60,10 @@ if (! function_exists('get_tag_image')) {
 }
 
 /**
- * { function_description }
+ * { function_description }.
  *
  * @param      <type>  $parent_id  The parent identifier
+ *
  * @return <type>  ( description_of_the_return_value )
  */
 function define_child($parent_id)
@@ -73,10 +74,11 @@ function define_child($parent_id)
 }
 
 /**
- * { function_description }
+ * { function_description }.
  *
  * @param      <type>  $id          The identifier
  * @param      <type>  $permission  The permission
+ *
  * @return <type>  ( description_of_the_return_value )
  */
 function permission_val($id, $permission)
@@ -98,9 +100,10 @@ function permission_name($name)
 }
 
 /**
- * Generate Password
+ * Generate Password.
  *
  * @param  int  $length  Length Character
+ *
  * @return string voucher
  */
 function generate_password($length = 6)
@@ -122,7 +125,7 @@ function generate_password($length = 6)
 }
 
 /**
- * Respon Meta
+ * Respon Meta.
  *
  * @param      <type>  $message  The message
  */
@@ -389,7 +392,7 @@ function terbilang($angka)
 
 if (! function_exists('sudahInstal')) {
     /**
-     * Cek apakah sudah install OpenDK atau belum
+     * Cek apakah sudah install OpenDK atau belum.
      *
      * @return bool True jika sudah install, False jika belum install
      */
@@ -405,7 +408,7 @@ if (! function_exists('sudahInstal')) {
 
 if (! function_exists('isActive')) {
     /**
-     * Helper function untuk installer views - cek apakah route aktif
+     * Helper function untuk installer views - cek apakah route aktif.
      *
      * @param  string  $routeName
      */
@@ -429,7 +432,7 @@ if (! function_exists('isActive')) {
     }
 }
 
-/**
+/*
  * Cek akses website.
  *
  * @param  string  $url
@@ -488,7 +491,7 @@ if (! function_exists('parsedown')) {
 
 if (! function_exists('theme_new')) {
     /**
-     * Ambil model tema
+     * Ambil model tema.
      *
      * @return Theme
      */
@@ -752,4 +755,19 @@ function kembalikanSlug($str): ?string
 {
     // Ganti '-' dengan spasi dan hilangkan titik '.'
     return str_replace(['-', '.'], [' ', ''], $str);
+}
+
+if (! function_exists('is_pdf')) {
+    function is_pdf($path = null, $mime = null): bool
+    {
+        if ($mime && str_contains(strtolower($mime), 'pdf')) {
+            return true;
+        }
+
+        if ($path && str_ends_with(strtolower($path), '.pdf')) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/resources/views/backend/event/form_create.blade.php
+++ b/resources/views/backend/event/form_create.blade.php
@@ -40,32 +40,41 @@
     <script type="application/javascript">
     var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'svg'];
     var imageTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'svg'];
+    var currentAttachmentBlobUrl = null;
 
     function readAttachmentURL(input) {
         if (input.files && input.files[0]) {
-            var extension = input.files[0].name.split('.').pop().toLowerCase();
+            var file = input.files[0];
+            var extension = file.name.split('.').pop().toLowerCase();
             var isSuccess = fileTypes.indexOf(extension) > -1;
 
             if (isSuccess) {
-                var reader = new FileReader();
-                reader.onload = function(e) {
-                    if (imageTypes.indexOf(extension) > -1) {
-                        $('#showgambar-attachment').attr('src', e.target.result);
-                        $('#showgambar-attachment').removeClass('hide');
-                        $('#showpdf-attachment').addClass('hide');
-                    } else if (extension === 'pdf') {
-                        $('#showpdf-attachment').attr('src', e.target.result + '#toolbar=1');
-                        $('#showpdf-attachment').removeClass('hide');
-                        $('#showgambar-attachment').addClass('hide');
-                    } else {
-                        $('#showgambar-attachment').addClass('hide');
-                        $('#showpdf-attachment').addClass('hide');
-                    }
-                };
-                reader.readAsDataURL(input.files[0]);
+                if (currentAttachmentBlobUrl) {
+                    URL.revokeObjectURL(currentAttachmentBlobUrl);
+                    currentAttachmentBlobUrl = null;
+                }
+
+                currentAttachmentBlobUrl = URL.createObjectURL(file);
+
+                if (imageTypes.indexOf(extension) > -1) {
+                    $('#showgambar-attachment').attr('src', currentAttachmentBlobUrl).removeClass('hide');
+                    $('#showpdf-attachment').addClass('hide').attr('src', '');
+                } else if (extension === 'pdf') {
+                    $('#showpdf-attachment').attr('src', currentAttachmentBlobUrl + '#toolbar=1').removeClass('hide');
+                    $('#showgambar-attachment').addClass('hide').attr('src', '');
+                } else {
+                    $('#showgambar-attachment').addClass('hide').attr('src', '');
+                    $('#showpdf-attachment').addClass('hide').attr('src', '');
+                }
             } else {
                 $('#attachment').val('');
-                alert('File tersebut tidak diperbolehkan.');
+                if (currentAttachmentBlobUrl) {
+                    URL.revokeObjectURL(currentAttachmentBlobUrl);
+                    currentAttachmentBlobUrl = null;
+                }
+                $('#showgambar-attachment').addClass('hide').attr('src', '');
+                $('#showpdf-attachment').addClass('hide').attr('src', '');
+                openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
             }
         }
     }

--- a/resources/views/backend/event/form_edit.blade.php
+++ b/resources/views/backend/event/form_edit.blade.php
@@ -84,32 +84,41 @@
     <script type="application/javascript">
         var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'svg'];
         var imageTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'svg'];
+        var currentAttachmentBlobUrl = null;
 
         function readAttachmentURL(input) {
             if (input.files && input.files[0]) {
-                var extension = input.files[0].name.split('.').pop().toLowerCase();
+                var file = input.files[0];
+                var extension = file.name.split('.').pop().toLowerCase();
                 var isSuccess = fileTypes.indexOf(extension) > -1;
 
                 if (isSuccess) {
-                    var reader = new FileReader();
-                    reader.onload = function(e) {
-                        if (imageTypes.indexOf(extension) > -1) {
-                            $('#showgambar-attachment').attr('src', e.target.result);
-                            $('#showgambar-attachment').removeClass('hide');
-                            $('#showpdf-attachment').addClass('hide');
-                        } else if (extension === 'pdf') {
-                            $('#showpdf-attachment').attr('src', e.target.result + '#toolbar=1');
-                            $('#showpdf-attachment').removeClass('hide');
-                            $('#showgambar-attachment').addClass('hide');
-                        } else {
-                            $('#showgambar-attachment').addClass('hide');
-                            $('#showpdf-attachment').addClass('hide');
-                        }
-                    };
-                    reader.readAsDataURL(input.files[0]);
+                    if (currentAttachmentBlobUrl) {
+                        URL.revokeObjectURL(currentAttachmentBlobUrl);
+                        currentAttachmentBlobUrl = null;
+                    }
+
+                    currentAttachmentBlobUrl = URL.createObjectURL(file);
+
+                    if (imageTypes.indexOf(extension) > -1) {
+                        $('#showgambar-attachment').attr('src', currentAttachmentBlobUrl).removeClass('hide');
+                        $('#showpdf-attachment').addClass('hide').attr('src', '');
+                    } else if (extension === 'pdf') {
+                        $('#showpdf-attachment').attr('src', currentAttachmentBlobUrl + '#toolbar=1').removeClass('hide');
+                        $('#showgambar-attachment').addClass('hide').attr('src', '');
+                    } else {
+                        $('#showgambar-attachment').addClass('hide').attr('src', '');
+                        $('#showpdf-attachment').addClass('hide').attr('src', '');
+                    }
                 } else {
                     $("#attachment").val('');
-                    alert('File tersebut tidak diperbolehkan.');
+                    if (currentAttachmentBlobUrl) {
+                        URL.revokeObjectURL(currentAttachmentBlobUrl);
+                        currentAttachmentBlobUrl = null;
+                    }
+                    $('#showgambar-attachment').addClass('hide').attr('src', '');
+                    $('#showpdf-attachment').addClass('hide').attr('src', '');
+                    openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                 }
             }
         }

--- a/resources/views/informasi/form_dokumen/form_edit.blade.php
+++ b/resources/views/informasi/form_dokumen/form_edit.blade.php
@@ -28,7 +28,7 @@
 <div class="form-group">
     <label class="control-label col-md-3 col-sm-3 col-xs-12">Unggah Dokumen</label>
     <div class="col-md-6 col-sm-6 col-xs-12">
-        {!! html()->file('file_dokumen')->class('form-control')->id('file_prosedur')->attribute('accept', '.jpeg,.png,.jpg,.gif,.svg,.xlsx,.xls,.doc,.docx,.pdf,.ppt,.pptx') !!}
+        {!! html()->file('file_dokumen')->class('form-control')->id('file_dokumen')->attribute('accept', '.jpeg,.png,.jpg,.gif,.svg,.xlsx,.xls,.doc,.docx,.pdf,.ppt,.pptx') !!}
         <br>
         @if (!empty($dokumen->file_dokumen))
             <a class="btn btn-sm btn-primary" href="{{ asset($dokumen->file_dokumen) }}">Download File</a>

--- a/resources/views/informasi/potensi/create.blade.php
+++ b/resources/views/informasi/potensi/create.blade.php
@@ -52,24 +52,39 @@
 @push('scripts')
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif'];
+            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop().toLowerCase();
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
                     var isSuccess = fileTypes.indexOf(extension) > -1;
 
                     if (isSuccess) {
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-                            $('#showgambar').attr('src', e.target.result);
-                            $('#showgambar').removeClass('hide');
-                        };
-                        reader.readAsDataURL(input.files[0]);
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
                     } else {
                         $("#file_gambar").val('');
-                        alert('File tersebut tidak diperbolehkan.');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
+                        openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }
             }

--- a/resources/views/informasi/potensi/edit.blade.php
+++ b/resources/views/informasi/potensi/edit.blade.php
@@ -51,24 +51,39 @@
 @push('scripts')
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif'];
+            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'gif', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop().toLowerCase();
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
                     var isSuccess = fileTypes.indexOf(extension) > -1;
 
                     if (isSuccess) {
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-                            $('#showgambar').attr('src', e.target.result);
-                            $('#showgambar').removeClass('hide');
-                        };
-                        reader.readAsDataURL(input.files[0]);
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
                     } else {
                         $("#file_gambar").val('');
-                        alert('File tersebut tidak diperbolehkan.');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
+                        openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }
             }

--- a/resources/views/informasi/potensi/form_create.blade.php
+++ b/resources/views/informasi/potensi/form_create.blade.php
@@ -23,13 +23,14 @@
     </div>
 </div>
 <div class="form-group">
-    <label class="control-label col-md-4 col-sm-3 col-xs-12">Gambar <span class="required">*</span></label>
+    <label class="control-label col-md-4 col-sm-3 col-xs-12">File Potensi <span class="required">*</span></label>
     <div class="col-md-5 col-sm-5 col-xs-12">
-        <input type="file" name="file_gambar" id="file_gambar" class="form-control" required accept=".jpg,.jpeg,.png,.bmp,.gif">
-        <x-upload-hint formats="JPG, JPEG, PNG, BMP, GIF" :limit-kb="1024" />
+        <input type="file" name="file_gambar" id="file_gambar" class="form-control" required accept=".jpg,.jpeg,.png,.bmp,.gif,.pdf">
+        <x-upload-hint formats="JPG, JPEG, PNG, BMP, GIF, PDF" :limit-kb="1024" />
         <div class="clearfix"></div>
         <br>
         <img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
+        <iframe src="" class="showpdf hide" id="showpdf" style="width: 100%; height: 400px; border: none;"></iframe>
     </div>
 </div>
 

--- a/resources/views/informasi/potensi/form_edit.blade.php
+++ b/resources/views/informasi/potensi/form_edit.blade.php
@@ -23,10 +23,10 @@
     </div>
 </div>
 <div class="form-group">
-    <label class="control-label col-md-4 col-sm-3 col-xs-12">Gambar</label>
+    <label class="control-label col-md-4 col-sm-3 col-xs-12">File Potensi</label>
     <div class="col-md-5 col-sm-6 col-xs-12">
-        <input type="file" name="file_gambar" id="file_gambar" class="form-control" accept=".jpg,.jpeg,.png,.bmp,.gif">
-        <x-upload-hint formats="JPG, JPEG, PNG, BMP, GIF" :limit-kb="1024" />
+        <input type="file" name="file_gambar" id="file_gambar" class="form-control" accept=".jpg,.jpeg,.png,.bmp,.gif,.pdf">
+        <x-upload-hint formats="JPG, JPEG, PNG, BMP, GIF, PDF" :limit-kb="1024" />
         <br />
 
         @if (isset($potensi->file_gambar) && $potensi->file_gambar)
@@ -34,7 +34,11 @@
                 $fileName = basename($potensi->file_gambar);
             @endphp
             <div style="padding:8px; background:#f5f5f5; border-radius:4px; margin-bottom:8px; display:flex; align-items:center; gap:10px;">
-                <img src="{{ is_img(str_replace('//', '/', $potensi->file_gambar)) }}" style="max-height:60px; max-width:90px; object-fit:contain; border-radius:3px;" class="img-thumbnail">
+                @if ($potensi->is_pdf)
+                    <i class="fa fa-file-pdf-o fa-2x text-danger"></i>
+                @else
+                    <img src="{{ is_img(str_replace('//', '/', $potensi->file_gambar)) }}" style="max-height:60px; max-width:90px; object-fit:contain; border-radius:3px;" class="img-thumbnail">
+                @endif
                 <div style="overflow: hidden;">
                     <span class="text-muted" style="word-break: break-all;">{{ $fileName }}</span><br>
                     <a href="{{ route('informasi.potensi.download', $potensi->id) }}" class="btn btn-xs btn-default" style="margin-top: 4px;">
@@ -43,13 +47,14 @@
                 </div>
             </div>
             <small class="help-block text-muted">
-                Upload gambar baru di atas untuk menggantikan gambar yang ada.
+                Upload file baru di atas untuk menggantikan file yang ada.
             </small>
         @endif
 
         <div class="clearfix"></div>
         <br>
         <img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
+        <iframe src="" class="showpdf hide" id="showpdf" style="width: 100%; height: 400px; border: none;"></iframe>
     </div>
 </div>
 

--- a/resources/views/informasi/potensi/show.blade.php
+++ b/resources/views/informasi/potensi/show.blade.php
@@ -21,6 +21,11 @@
                             <button type="button" class="btn btn-default btn-sm"><i class="fa fa-arrow-left"></i>&nbsp;
                                 Kembali</button>
                         </a>
+                        @if (!empty($potensi->file_gambar))
+                            <a href="{{ route('informasi.potensi.download', $potensi->id) }}" class="btn btn-sm btn-info">
+                                <i class="fa fa-download"></i>&nbsp; Unduh
+                            </a>
+                        @endif
                         <a href="{!! route('informasi.potensi.edit', $potensi->id) !!}" class="btn btn-sm btn-primary" title="Ubah" data-button="edit"><i class="fa fa-edit"></i>&nbsp; Ubah</a>
 
                         <a href="javascript:void(0)" class="" title="Hapus" data-href="{!! route('informasi.potensi.destroy', $potensi->id) !!}" data-button="delete" id="deleteModal">
@@ -32,7 +37,15 @@
                         <!-- form start -->
                         <div class="row overflow-x">
                             <div class="col-md-12">
-                                <img src="{{ is_img(str_replace('//', '/', $potensi->file_gambar)) }}" width="100%">
+                                @if (!empty($potensi->file_gambar))
+                                    @if ($potensi->is_pdf)
+                                        <iframe src="{{ asset($potensi->file_gambar) }}#toolbar=1" class="showpdf" id="showpdf" style="width: 100%; height: 750px; border: 1px solid #e0e0e0; border-radius: 4px;" frameborder="0">
+                                            <p>Browser Anda tidak mendukung preview PDF langsung. <a href="{{ route('informasi.potensi.download', $potensi->id) }}">Klik di sini untuk mengunduh</a>.</p>
+                                        </iframe>
+                                    @else
+                                        <img src="{{ is_img(str_replace('//', '/', $potensi->file_gambar)) }}" class="img-responsive" style="max-width: 100%; margin: 0 auto; display: block;">
+                                    @endif
+                                @endif
                             </div>
                             <div class="col-md-12">
                                 <h3>{{ $potensi->nama_potensi }}</h3>

--- a/resources/views/informasi/prosedur/create.blade.php
+++ b/resources/views/informasi/prosedur/create.blade.php
@@ -52,35 +52,38 @@
 @push('scripts')
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'pdf']; //acceptable file types
+            var fileTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop()
-                        .toLowerCase(), //file extension from input file
-                        isSuccess = fileTypes.indexOf(extension) > -1; //is extension in acceptable types
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
+                    var isSuccess = fileTypes.indexOf(extension) > -1;
 
-                    if (isSuccess) { //yes
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-
-                            if (extension != 'pdf') {
-                                $('#showgambar').attr('src', e.target.result);
-                                $('#showgambar').removeClass('hide');
-                                $('#showpdf').addClass('hide');
-                            } else {
-                                $('#showpdf').attr('src', e.target.result + '#toolbar=1');
-                                $('#showpdf').removeClass('hide');
-                                $('#showgambar').addClass('hide');
-                            }
-
+                    if (isSuccess) {
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
                         }
 
-                        reader.readAsDataURL(input.files[0]);
-                    } else { //no
-                        //warning
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
+                    } else {
                         $("#file_prosedur").val('');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
                         openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }

--- a/resources/views/informasi/prosedur/edit.blade.php
+++ b/resources/views/informasi/prosedur/edit.blade.php
@@ -50,35 +50,38 @@
 @push('scripts')
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'pdf']; //acceptable file types
+            var fileTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop()
-                        .toLowerCase(), //file extension from input file
-                        isSuccess = fileTypes.indexOf(extension) > -1; //is extension in acceptable types
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
+                    var isSuccess = fileTypes.indexOf(extension) > -1;
 
-                    if (isSuccess) { //yes
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-
-                            if (extension != 'pdf') {
-                                $('#showgambar').attr('src', e.target.result);
-                                $('#showgambar').removeClass('hide');
-                                $('#showpdf').addClass('hide');
-                            } else {
-                                $('#showpdf').attr('src', e.target.result + '#toolbar=1');
-                                $('#showpdf').removeClass('hide');
-                                $('#showgambar').addClass('hide');
-                            }
-
+                    if (isSuccess) {
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
                         }
 
-                        reader.readAsDataURL(input.files[0]);
-                    } else { //no
-                        //warning
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
+                    } else {
                         $("#file_prosedur").val('');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
                         openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }

--- a/resources/views/informasi/prosedur/index.blade.php
+++ b/resources/views/informasi/prosedur/index.blade.php
@@ -74,17 +74,8 @@
                     [1, 'asc']
                 ]
             });
-            // Event untuk tombol pratinjau
-            $(document).on('click', '.btn-preview-surat', function(e) {
-                e.preventDefault();
-                var url = $(this).data('url');
-                $('#modalPreviewSuratLabel').text('Pratinjau');
-                $('#modalPreviewSurat .modal-body').html('<iframe src="' + url + '" width="100%" height="500px" style="border:none;"></iframe>');
-                $('#modalPreviewSurat').modal('show');
-            });
         });
     </script>
-    @include('components.modal-preview-surat')
     @include('forms.datatable-vertical')
     @include('forms.delete-modal')
 @endpush

--- a/resources/views/informasi/prosedur/show.blade.php
+++ b/resources/views/informasi/prosedur/show.blade.php
@@ -18,21 +18,28 @@
                 <div class="box box-primary">
                     <div class="box-header with-border">
                         <a href="{{ route('informasi.prosedur.index') }}">
-                            <button type="button" class="btn btn-primary btn-sm"><i class="fa fa-arrow-left"></i>&nbsp;
+                            <button type="button" class="btn btn-default btn-sm"><i class="fa fa-arrow-left"></i>&nbsp;
                                 Kembali</button>
                         </a>
+                        @if (!empty($prosedur->file_prosedur))
+                            <a href="{{ route('informasi.prosedur.download', $prosedur->id) }}" class="btn btn-primary btn-sm">
+                                <i class="fa fa-download"></i>&nbsp; Unduh
+                            </a>
+                        @endif
                     </div>
                     <!-- /.box-header -->
                     <div class="box-body">
                         <!-- form start -->
                         <div class="row overflow-x">
                             <div class="col-md-12">
-                                @if (isset($prosedur->file_prosedur) && $prosedur->mime_type != 'pdf')
-                                    <img src="{{ asset($prosedur->file_prosedur) }}" width="100%">
-                                @endif
-
-                                @if (isset($prosedur->file_prosedur) && $prosedur->mime_type == 'pdf')
-                                    <object data="@if (isset($prosedur->file_prosedur)) {{ asset($prosedur->file_prosedur . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf" id="showpdf"> </object>
+                                @if (!empty($prosedur->file_prosedur))
+                                    @if ($prosedur->is_pdf)
+                                        <iframe src="{{ asset($prosedur->file_prosedur) }}#toolbar=1" class="showpdf" id="showpdf" style="width: 100%; height: 750px; border: 1px solid #e0e0e0; border-radius: 4px;" frameborder="0">
+                                            <p>Browser Anda tidak mendukung preview PDF langsung. <a href="{{ route('informasi.prosedur.download', $prosedur->id) }}">Klik di sini untuk mengunduh</a>.</p>
+                                        </iframe>
+                                    @else
+                                        <img src="{{ asset($prosedur->file_prosedur) }}" class="img-responsive" style="max-width: 100%; margin: 0 auto; display: block;">
+                                    @endif
                                 @endif
                             </div>
                         </div>

--- a/resources/views/informasi/regulasi/form_create.blade.php
+++ b/resources/views/informasi/regulasi/form_create.blade.php
@@ -19,20 +19,12 @@
 <div class="form-group">
     <label class="control-label col-md-3 col-sm-3 col-xs-12">File Regulasi <span class="required">*</span></label>
     <div class="col-md-6 col-sm-6 col-xs-12">
-        <input accept="image/*, application/pdf" type="file" id="file_regulasi" name="file_regulasi" class="form-control" required>
+        <input accept=".jpg,.jpeg,.png,.gif,.pdf" type="file" id="file_regulasi" name="file_regulasi" class="form-control" required>
+        <x-upload-hint formats="JPG, JPEG, PNG, GIF, PDF" />
+        <div class="clearfix"></div>
         <br>
-
-        @if (isset($regulasi->file_regulasi) && $regulasi->mime_type != 'pdf')
-            <img class="" src="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi) }} @else {{ 'http://placehold.co/1000x600' }} @endif" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
-        @endif
-
-        @if (isset($regulasi->file_regulasi) && $regulasi->mime_type == 'pdf')
-            <object data="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf" id="showpdf"> </object>
-        @endif
-
-        <img class="hide" src="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi) }} @else {{ 'http://placehold.co/1000x600' }} @endif" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
-
-        <object data="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf hide" id="showpdf"> </object>
+        <img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
+        <iframe src="" class="showpdf hide" id="showpdf" style="width: 100%; height: 400px; border: none;"></iframe>
     </div>
 </div>
 
@@ -45,34 +37,38 @@
 
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'pdf']; //acceptable file types
+            var fileTypes = ['jpg', 'jpeg', 'png', 'gif', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop().toLowerCase(), //file extension from input file
-                        isSuccess = fileTypes.indexOf(extension) > -1; //is extension in acceptable types
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
+                    var isSuccess = fileTypes.indexOf(extension) > -1;
 
-                    if (isSuccess) { //yes
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-
-                            if (extension != 'pdf') {
-                                $('#showgambar').attr('src', e.target.result);
-                                $('#showgambar').removeClass('hide');
-                                $('#showpdf').addClass('hide');
-                            } else {
-                                $('#showpdf').attr('data', e.target.result + '#toolbar=1');
-                                $('#showpdf').removeClass('hide');
-                                $('#showgambar').addClass('hide');
-                            }
-
+                    if (isSuccess) {
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
                         }
 
-                        reader.readAsDataURL(input.files[0]);
-                    } else { //no
-                        //warning
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
+                    } else {
                         $("#file_regulasi").val('');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
                         openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }

--- a/resources/views/informasi/regulasi/form_update.blade.php
+++ b/resources/views/informasi/regulasi/form_update.blade.php
@@ -19,20 +19,33 @@
 <div class="form-group">
     <label class="control-label col-md-3 col-sm-3 col-xs-12">File Regulasi <span class="required">*</span></label>
     <div class="col-md-6 col-sm-6 col-xs-12">
-        <input accept="image/*, application/pdf" type="file" id="file_regulasi" name="file_regulasi" class="form-control">
+        <input accept=".jpg,.jpeg,.png,.gif,.pdf" type="file" id="file_regulasi" name="file_regulasi" class="form-control">
+        <x-upload-hint formats="JPG, JPEG, PNG, GIF, PDF" />
+        <br />
+
+        @if (isset($regulasi->file_regulasi))
+            <div style="padding:8px; background:#f5f5f5; border-radius:4px; margin-bottom:8px; display:flex; align-items:center; gap:10px;">
+                @if ($regulasi->is_pdf)
+                    <i class="fa fa-file-pdf-o fa-2x text-danger"></i>
+                @else
+                    <img src="{{ asset($regulasi->file_regulasi) }}" style="max-height:60px; max-width:90px; object-fit:contain; border-radius:3px;" class="img-thumbnail">
+                @endif
+                <div style="overflow: hidden;">
+                    <span class="text-muted" style="word-break: break-all;">{{ basename($regulasi->file_regulasi) }}</span><br>
+                    <a href="{{ route('informasi.regulasi.download', $regulasi->id) }}" class="btn btn-xs btn-default" style="margin-top: 4px;">
+                        <i class="fa fa-download"></i> Unduh
+                    </a>
+                </div>
+            </div>
+            <small class="help-block text-muted">
+                Upload file baru di atas untuk menggantikan file yang ada.
+            </small>
+        @endif
+
+        <div class="clearfix"></div>
         <br>
-
-        @if (isset($regulasi->file_regulasi) && $regulasi->mime_type != 'pdf')
-            <img class="" src="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi) }} @else {{ 'http://placehold.co/1000x600' }} @endif" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
-        @endif
-
-        @if (isset($regulasi->file_regulasi) && $regulasi->mime_type == 'pdf')
-            <object data="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf" id="showpdf"> </object>
-        @endif
-
-        <img class="hide" src="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi) }} @else {{ 'http://placehold.co/1000x600' }} @endif" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
-
-        <object data="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf hide" id="showpdf"> </object>
+        <img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
+        <iframe src="" class="showpdf hide" id="showpdf" style="width: 100%; height: 400px; border: none;"></iframe>
     </div>
 </div>
 
@@ -45,34 +58,38 @@
 
     <script>
         $(function() {
-
-            var fileTypes = ['jpg', 'jpeg', 'png', 'bmp', 'pdf']; //acceptable file types
+            var fileTypes = ['jpg', 'jpeg', 'png', 'gif', 'pdf'];
+            var currentBlobUrl = null;
 
             function readURL(input) {
                 if (input.files && input.files[0]) {
-                    var extension = input.files[0].name.split('.').pop().toLowerCase(), //file extension from input file
-                        isSuccess = fileTypes.indexOf(extension) > -1; //is extension in acceptable types
+                    var file = input.files[0];
+                    var extension = file.name.split('.').pop().toLowerCase();
+                    var isSuccess = fileTypes.indexOf(extension) > -1;
 
-                    if (isSuccess) { //yes
-                        var reader = new FileReader();
-                        reader.onload = function(e) {
-
-                            if (extension != 'pdf') {
-                                $('#showgambar').attr('src', e.target.result);
-                                $('#showgambar').removeClass('hide');
-                                $('#showpdf').addClass('hide');
-                            } else {
-                                $('#showpdf').attr('data', e.target.result + '#toolbar=1');
-                                $('#showpdf').removeClass('hide');
-                                $('#showgambar').addClass('hide');
-                            }
-
+                    if (isSuccess) {
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
                         }
 
-                        reader.readAsDataURL(input.files[0]);
-                    } else { //no
-                        //warning
+                        currentBlobUrl = URL.createObjectURL(file);
+
+                        if (extension !== 'pdf') {
+                            $('#showgambar').attr('src', currentBlobUrl).removeClass('hide');
+                            $('#showpdf').addClass('hide').attr('src', '');
+                        } else {
+                            $('#showpdf').attr('src', currentBlobUrl + '#toolbar=1').removeClass('hide');
+                            $('#showgambar').addClass('hide').attr('src', '');
+                        }
+                    } else {
                         $("#file_regulasi").val('');
+                        if (currentBlobUrl) {
+                            URL.revokeObjectURL(currentBlobUrl);
+                            currentBlobUrl = null;
+                        }
+                        $('#showgambar').addClass('hide').attr('src', '');
+                        $('#showpdf').addClass('hide').attr('src', '');
                         openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
                     }
                 }

--- a/resources/views/informasi/regulasi/show.blade.php
+++ b/resources/views/informasi/regulasi/show.blade.php
@@ -18,9 +18,14 @@
                 <div class="box box-primary">
                     <div class="box-header with-border">
                         <a href="{{ route('informasi.regulasi.index') }}">
-                            <button type="button" class="btn btn-primary btn-sm"><i class="fa fa-arrow-left"></i>&nbsp;
+                            <button type="button" class="btn btn-default btn-sm"><i class="fa fa-arrow-left"></i>&nbsp;
                                 Kembali</button>
                         </a>
+                        @if (!empty($regulasi->file_regulasi))
+                            <a href="{{ route('informasi.regulasi.download', $regulasi->id) }}" class="btn btn-primary btn-sm">
+                                <i class="fa fa-download"></i>&nbsp; Unduh
+                            </a>
+                        @endif
                     </div>
                     <!-- /.box-header -->
                     <div class="box-body">
@@ -29,13 +34,15 @@
                             <div class="col-md-12">
                                 <label>Deskripsi : </label>
                                 <p>{{ $regulasi->deskripsi }}</p>
-                                </hr>
-                                @if (isset($regulasi->file_regulasi) && $regulasi->mime_type != 'pdf')
-                                    <img src="{{ asset($regulasi->file_regulasi) }}" width="100%">
-                                @endif
-
-                                @if (isset($regulasi->file_regulasi) && $regulasi->mime_type == 'pdf')
-                                    <object data="@if (isset($regulasi->file_regulasi)) {{ asset($regulasi->file_regulasi . '#toolbar=1') }} @endif" type="application/pdf" class="showpdf" id="showpdf"> </object>
+                                <hr>
+                                @if (!empty($regulasi->file_regulasi))
+                                    @if ($regulasi->is_pdf)
+                                        <iframe src="{{ asset($regulasi->file_regulasi) }}#toolbar=1" class="showpdf" id="showpdf" style="width: 100%; height: 750px; border: 1px solid #e0e0e0; border-radius: 4px;" frameborder="0">
+                                            <p>Browser Anda tidak mendukung preview PDF langsung. <a href="{{ route('informasi.regulasi.download', $regulasi->id) }}">Klik di sini untuk mengunduh</a>.</p>
+                                        </iframe>
+                                    @else
+                                        <img src="{{ asset($regulasi->file_regulasi) }}" class="img-responsive" style="max-width: 100%; margin: 0 auto; display: block;">
+                                    @endif
                                 @endif
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -346,7 +346,6 @@ Route::group(['middleware' => ['installed', 'xss_sanitization']], function () {
                     Route::put('update/{prosedur}', ['as' => 'informasi.prosedur.update', 'uses' => 'ProsedurController@update']);
                     Route::delete('destroy/{prosedur}', ['as' => 'informasi.prosedur.destroy', 'uses' => 'ProsedurController@destroy']);
                     Route::get('download/{prosedur}', ['as' => 'informasi.prosedur.download', 'uses' => 'ProsedurController@download']);
-                    Route::get('preview/{prosedur}', ['as' => 'informasi.prosedur.preview', 'uses' => 'ProsedurController@preview']);
                 });
 
                 // Regulasi

--- a/tests/Feature/FilePreviewFeatureTest.php
+++ b/tests/Feature/FilePreviewFeatureTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\CompleteProfile;
+use App\Models\Potensi;
+use App\Models\Prosedur;
+use App\Models\Regulasi;
+use App\Models\TipePotensi;
+use App\Models\TipeRegulasi;
+use App\Models\User;
+
+describe('File Preview Feature & Security Tests', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware([CompleteProfile::class]);
+
+        $this->user = User::first();
+        $this->actingAs($this->user);
+
+        // Prepare test directory
+        $this->testDir = public_path('storage/test_previews');
+        if (!file_exists($this->testDir)) {
+            mkdir($this->testDir, 0777, true);
+        }
+
+        // Create dummy PDF and Image files
+        $this->pdfPath = $this->testDir . '/sample.pdf';
+        file_put_contents($this->pdfPath, "%PDF-1.4\n%test pdf content");
+
+        $this->imgPath = $this->testDir . '/sample.png';
+        // 1x1 transparent PNG
+        file_put_contents($this->imgPath, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='));
+    });
+
+    afterEach(function () {
+        if (file_exists($this->pdfPath)) {
+            @unlink($this->pdfPath);
+        }
+        if (file_exists($this->imgPath)) {
+            @unlink($this->imgPath);
+        }
+        if (is_dir($this->testDir)) {
+            @rmdir($this->testDir);
+        }
+    });
+
+    test('prosedur show page renders iframe for PDF and img for image', function () {
+        $prosedurPdf = Prosedur::create([
+            'judul_prosedur' => 'Prosedur Test PDF',
+            'file_prosedur'  => 'storage/test_previews/sample.pdf',
+            'mime_type'      => 'application/pdf',
+        ]);
+
+        $responsePdf = $this->get(route('informasi.prosedur.show', $prosedurPdf->id));
+        $responsePdf->assertStatus(200);
+        $responsePdf->assertSee('<iframe', false);
+        $responsePdf->assertSee('class="showpdf"', false);
+
+        $prosedurImg = Prosedur::create([
+            'judul_prosedur' => 'Prosedur Test Image',
+            'file_prosedur'  => 'storage/test_previews/sample.png',
+            'mime_type'      => 'image/png',
+        ]);
+
+        $responseImg = $this->get(route('informasi.prosedur.show', $prosedurImg->id));
+        $responseImg->assertStatus(200);
+        $responseImg->assertSee('<img', false);
+
+        $prosedurPdf->delete();
+        $prosedurImg->delete();
+    });
+
+    test('regulasi show page renders iframe for PDF and img for image', function () {
+        $tipe = TipeRegulasi::first();
+
+        $regulasiPdf = Regulasi::create([
+            'tipe_regulasi' => $tipe->id,
+            'judul'         => 'Regulasi Test PDF',
+            'deskripsi'     => 'Deskripsi Regulasi PDF',
+            'file_regulasi' => 'storage/test_previews/sample.pdf',
+            'mime_type'     => 'application/pdf',
+        ]);
+
+        $responsePdf = $this->get(route('informasi.regulasi.show', $regulasiPdf->id));
+        $responsePdf->assertStatus(200);
+        $responsePdf->assertSee('<iframe', false);
+        $responsePdf->assertSee('class="showpdf"', false);
+
+        $regulasiImg = Regulasi::create([
+            'tipe_regulasi' => $tipe->id,
+            'judul'         => 'Regulasi Test Image',
+            'deskripsi'     => 'Deskripsi Regulasi Image',
+            'file_regulasi' => 'storage/test_previews/sample.png',
+            'mime_type'     => 'image/png',
+        ]);
+
+        $responseImg = $this->get(route('informasi.regulasi.show', $regulasiImg->id));
+        $responseImg->assertStatus(200);
+        $responseImg->assertSee('<img', false);
+
+        $regulasiPdf->delete();
+        $regulasiImg->delete();
+    });
+
+    test('potensi show page renders iframe for PDF and img for image', function () {
+        $tipe = TipePotensi::first();
+
+        $potensiPdf = Potensi::create([
+            'kategori_id'  => $tipe->id,
+            'nama_potensi' => 'Potensi Wisata PDF',
+            'deskripsi'    => 'Deskripsi Potensi PDF',
+            'lokasi'       => 'Lokasi Wisata',
+            'file_gambar'  => 'storage/test_previews/sample.pdf',
+            'mime_type'    => 'application/pdf',
+        ]);
+
+        $responsePdf = $this->get(route('informasi.potensi.show', $potensiPdf->id));
+        $responsePdf->assertStatus(200);
+        $responsePdf->assertSee('<iframe', false);
+        $responsePdf->assertSee('class="showpdf"', false);
+
+        $potensiImg = Potensi::create([
+            'kategori_id'  => $tipe->id,
+            'nama_potensi' => 'Potensi Wisata Image',
+            'deskripsi'    => 'Deskripsi Potensi Image',
+            'lokasi'       => 'Lokasi Wisata',
+            'file_gambar'  => 'storage/test_previews/sample.png',
+            'mime_type'    => 'image/png',
+        ]);
+
+        $responseImg = $this->get(route('informasi.potensi.show', $potensiImg->id));
+        $responseImg->assertStatus(200);
+        $responseImg->assertSee('<img', false);
+
+        $potensiPdf->delete();
+        $potensiImg->delete();
+    });
+
+    test('download rejects path traversal attempts securely', function () {
+        $prosedurEvil = Prosedur::create([
+            'judul_prosedur' => 'Evil Prosedur',
+            'file_prosedur'  => '../../../../Windows/win.ini',
+            'mime_type'      => 'application/pdf',
+        ]);
+
+        // Download attempt with traversal path should not return the file
+        $downloadResponse = $this->get(route('informasi.prosedur.download', $prosedurEvil->id));
+        expect($downloadResponse->status())->toBeIn([302, 403, 404]);
+
+        $prosedurEvil->delete();
+    });
+});

--- a/tests/Unit/FilePreviewSecurityTest.php
+++ b/tests/Unit/FilePreviewSecurityTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Http\Middleware\SecurityHeaders;
+use App\Models\Potensi;
+use App\Models\Prosedur;
+use App\Models\Regulasi;
+use App\Traits\HandlesFileUpload;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+// Dummy class to test HandlesFileUpload trait
+class FileUploadSecurityTestHelper
+{
+    use HandlesFileUpload;
+
+    public function testResolvePath(?string $path): ?string
+    {
+        return $this->resolveSecureFilePath($path);
+    }
+}
+
+describe('File Preview Security & Detection Tests', function () {
+
+    test('is_pdf helper correctly identifies PDF paths and MIME types', function () {
+        expect(is_pdf('doc.pdf'))->toBeTrue();
+        expect(is_pdf('DOC.PDF'))->toBeTrue();
+        expect(is_pdf('storage/files/prosedur.pdf'))->toBeTrue();
+        expect(is_pdf(null, 'application/pdf'))->toBeTrue();
+        expect(is_pdf(null, 'pdf'))->toBeTrue();
+        expect(is_pdf('doc.png', 'application/pdf'))->toBeTrue();
+        expect(is_pdf('photo.png', 'image/png'))->toBeFalse();
+        expect(is_pdf('photo.jpg'))->toBeFalse();
+        expect(is_pdf(null, null))->toBeFalse();
+    });
+
+    test('models have functional is_pdf attribute', function () {
+        $prosedurPdf = new Prosedur(['file_prosedur' => 'storage/doc.pdf', 'mime_type' => 'application/pdf']);
+        expect($prosedurPdf->is_pdf)->toBeTrue();
+
+        $prosedurImg = new Prosedur(['file_prosedur' => 'storage/pic.jpg', 'mime_type' => 'image/jpeg']);
+        expect($prosedurImg->is_pdf)->toBeFalse();
+
+        $regulasiPdf = new Regulasi(['file_regulasi' => 'storage/sk.pdf', 'mime_type' => 'application/pdf']);
+        expect($regulasiPdf->is_pdf)->toBeTrue();
+
+        $regulasiImg = new Regulasi(['file_regulasi' => 'storage/banner.png', 'mime_type' => 'image/png']);
+        expect($regulasiImg->is_pdf)->toBeFalse();
+
+        $potensiPdf = new Potensi(['file_gambar' => 'storage/wisata.pdf', 'mime_type' => 'application/pdf']);
+        expect($potensiPdf->is_pdf)->toBeTrue();
+
+        $potensiImg = new Potensi(['file_gambar' => 'storage/wisata.png', 'mime_type' => 'image/png']);
+        expect($potensiImg->is_pdf)->toBeFalse();
+    });
+
+    test('HandlesFileUpload rejects path traversal and files outside allowed directories', function () {
+        $helper = new FileUploadSecurityTestHelper();
+
+        // Null and empty paths
+        expect($helper->testResolvePath(null))->toBeNull();
+        expect($helper->testResolvePath(''))->toBeNull();
+
+        // Path traversal attempts
+        expect($helper->testResolvePath('../../../Windows/win.ini'))->toBeNull();
+        expect($helper->testResolvePath('..\\..\\..\\Windows\\win.ini'))->toBeNull();
+        expect($helper->testResolvePath('storage/../../../../etc/passwd'))->toBeNull();
+        expect($helper->testResolvePath('/etc/passwd'))->toBeNull();
+
+        // Safe resolution for real file inside public_path
+        $tempFile = public_path('test_preview_security_probe.txt');
+        file_put_contents($tempFile, 'safe content');
+
+        try {
+            $resolved = $helper->testResolvePath('test_preview_security_probe.txt');
+            expect($resolved)->not->toBeNull();
+            expect(realpath($resolved))->toBe(realpath($tempFile));
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    });
+
+    test('SecurityHeaders middleware enforces secure CSP in production', function () {
+        app()['env'] = 'production';
+        try {
+            $middleware = new SecurityHeaders();
+            $request = Request::create('/', 'GET');
+            $response = $middleware->handle($request, function () {
+                return new Response('<html><body>Hello</body></html>');
+            });
+
+            $csp = $response->headers->get('Content-Security-Policy');
+            expect($csp)->not->toBeNull();
+
+            // Verify CSP directives for secure PDF preview
+            expect($csp)->toContain("object-src 'self' blob:");
+            expect($csp)->toContain("frame-src 'self' blob: data:");
+            expect($csp)->toContain("img-src 'self' * data: blob:");
+            expect($csp)->toContain("frame-ancestors 'self'");
+            expect($csp)->not->toContain('report-uri ;');
+        } finally {
+            app()['env'] = 'testing';
+        }
+    });
+
+});

--- a/themes/opendk/default/resources/views/pages/potensi/show.blade.php
+++ b/themes/opendk/default/resources/views/pages/potensi/show.blade.php
@@ -30,10 +30,14 @@
                 success: function(response) {
                     if (response.data && response.data.length > 0) {
                         var potensi = response.data[0].attributes;                                                
+                        let isPdf = (potensi.mime_type === 'application/pdf' || (potensi.file_gambar && potensi.file_gambar.toLowerCase().endsWith('.pdf')) || (potensi.file_gambar_path && potensi.file_gambar_path.toLowerCase().endsWith('.pdf')));
+                        let mediaHtml = isPdf
+                            ? '<iframe src="' + (potensi.file_gambar_path || '') + '#toolbar=1" width="100%" height="550" style="border: 1px solid #e0e0e0; border-radius: 4px;" frameborder="0"></iframe>'
+                            : '<img src="' + (potensi.file_gambar_path || "{{ asset('/img/no-image.png') }}") + '" width="100%">';
                         
                         // Generate potensi detail HTML
-                        var potensiHtml = '<div class="col-md-12">' +
-                            '<img src="' + (potensi.file_gambar_path || "{{ asset('/img/no-image.png') }}") + '" width="100%">' +
+                        var potensiHtml = '<div class="col-md-12 text-center" style="margin-bottom: 20px;">' +
+                            mediaHtml +
                             '</div>' +
                             '<div class="col-md-12">' +
                             '<h3>' + (potensi.nama_potensi || '') + '</h3>' +


### PR DESCRIPTION
issue # https://github.com/OpenSID/OpenDK/issues/1725

## 🎯 Deskripsi

Pull request ini menyelesaikan permasalahan pada pratinjau (*preview*) berkas dokumen dan gambar pada menu **Prosedur**, **Regulasi**, dan **Potensi**, baik saat proses pengunggahan berkas (form tambah/ubah) maupun pada halaman rincian (*show/detail*), serta memperkuat proteksi keamanan terkait Content Security Policy (CSP) dan pencegahan Path Traversal, serta menyesuaikan frontend potensi.

### Permasalahan yang Ditemukan:
1. **Pratinjau Unggah Berkas Menggunakan `readAsDataURL` ke Tag `<img>`:**
   Pada form create dan edit di modul Prosedur, Regulasi, dan Potensi, skrip pratinjau JavaScript membaca berkas menggunakan `FileReader.readAsDataURL()` lalu memasukkannya ke atribut `src` elemen `<img>`. Ketika pengguna mengunggah berkas PDF, elemen `<img>` tidak dapat merender berkas PDF sehingga menghasilkan ikon gambar rusak (*broken image icon*). Selain itu, konversi berkas besar ke Base64 Data URL membebani memori peramban (*browser memory leak*).
2. **Halaman Detail (*Show*) Memaksa Berkas PDF ke Tag `<img>`:**
   Halaman detail (`show.blade.php`) merender berkas langsung menggunakan tag `<img>`. Jika berkas yang diunggah berupa dokumen PDF, peramban menampilkan ikon gambar rusak dan dokumen tidak dapat dibaca oleh pengguna.
3. **Menu Potensi Belum Mendukung Berkas PDF:**
   Menu Potensi sebelumnya hanya mengizinkan pengunggahan gambar (`mimes:jpg,jpeg,png`). Padahal dalam proses bisnis pemerintahan kecamatan, informasi potensi daerah kerap kali berbentuk dokumen kajian atau profil potensi berformat PDF.
4. **Kebijakan CSP (*Content Security Policy*) dan Keamanan Berkas:**
   - Direktif CSP sebelumnya belum mengizinkan sumber `blob:` pada `object-src` dan `frame-src`, yang berpotensi memblokir pratinjau dokumen secara aman di peramban modern.
   - Fungsi pengunduhan berkas (`download`) pada controller memerlukan validasi sanitasi jalur berkas yang ketat untuk mencegah serangan *Path Traversal* (*Local File Inclusion*).

---

### Solusi yang Diterapkan:
1. **Pratinjau Unggah Sisi Klien Efisien & Dinamis (Blob Object URL):**
   - Mengganti `FileReader.readAsDataURL` dengan `URL.createObjectURL(file)`.
   - Mendeteksi tipe berkas (`image/*` vs `application/pdf`). Jika gambar, ditampilkan pada wadah `<img>`; jika PDF, ditampilkan indikator dokumen PDF yang bersih atau pratinjau dokumen, serta memanggil `URL.revokeObjectURL()` saat berkas diganti atau dilepas guna mencegah kebocoran memori.
2. **Pratinjau Halaman Detail Berbasis `<iframe>` Responsif:**
   - Memeriksa ekstensi dan MIME type berkas melalui *accessor* model `$item->is_pdf`.
   - Jika berkas merupakan PDF, halaman detail merender komponen `<iframe>` yang responsif (`w-full`, tinggi minimal 600px, `border-0`) dilengkapi tombol aksi pengunduhan langsung (*direct download button*).
   - Jika berkas merupakan gambar, ditampilkan menggunakan elemen `<img>` yang responsif.
3. **Dukungan Berkas PDF pada Menu Potensi:**
   - Membuat migrasi database untuk menambahkan kolom `mime_type` pada tabel `das_potensi`.
   - Memperbarui `PotensiRequest` untuk mendukung validasi `mimes:jpg,jpeg,png,pdf` hingga ukuran 10MB.
   - Memperbarui `PotensiController` untuk mendeteksi dan menyimpan MIME type, serta menyesuaikan tampilan halaman detail admin dan halaman publik tema OpenDK default.
4. **Penguatan Keamanan (Security Hardening):**
   - **Content Security Policy (CSP):** Mengonfigurasi `SecurityHeaders` middleware dengan direktif `object-src 'self' blob:`, `frame-src 'self' blob: data: ...`, `img-src 'self' * data: blob:`, dan `frame-ancestors 'self'` untuk mencegah *clickjacking*.
   - **Pencegahan Path Traversal:** Menambahkan metode `resolveSecureFilePath()` pada *trait* `HandlesFileUpload` yang memvalidasi `realpath()` berkas terhadap direktori dasar penyimpanan yang diizinkan sebelum mengeksekusi `response()->download()`.
5. **Standarisasi dan Pembersihan Kode:**
   - Memperbaiki ketidakkonsistenan penamaan ID pada form Event dan Form Dokumen.
   - Menghapus referensi `preview_url` dan metode `preview()` yang tidak terpakai pada datatables aksi sesuai kebutuhan aplikasi.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `app/Http/Middleware/SecurityHeaders.php`

**Security — Penyesuaian CSP untuk Pratinjau Dokumen dan Proteksi Clickjacking:**

- Mengizinkan skema `blob:` dan `data:` pada `frame-src` dan `object-src` agar pratinjau PDF di peramban tidak terblokir oleh CSP.
- Menetapkan `frame-ancestors 'self'` untuk memastikan aplikasi terlindungi dari serangan *clickjacking*.

```diff
-            "frame-src 'self' https://www.google.com https://maps.google.com https://www.youtube.com;",
-            "object-src 'none';",
+            "frame-src 'self' blob: data: https://www.google.com https://maps.google.com https://www.youtube.com;",
+            "object-src 'self' blob:;",
```

---

### 2. `app/Traits/HandlesFileUpload.php`

**Security — Mitigasi Path Traversal pada Pengunduhan Berkas:**

- Menambahkan metode `resolveSecureFilePath()` untuk memastikan berkas yang diminta berada di dalam direktori penyimpanan yang sah sebelum disajikan untuk unduhan.

```diff
+    public function resolveSecureFilePath(string $filePath, array $allowedBases = []): ?string
+    {
+        $normalizedRelative = ltrim(str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $filePath), DIRECTORY_SEPARATOR);
+
+        if (empty($allowedBases)) {
+            $allowedBases = [
+                storage_path('app/public'),
+                storage_path('app'),
+                public_path(),
+            ];
+        }
+        ...
+        return $resolved;
+    }
```

---

### 3. `helpers/general_helper.php` & Models

**Feature & Refactor — Pendeteksian Berkas PDF:**

- Menambahkan fungsi pembantu (*helper*) `is_pdf($path = null, $mime = null)`.
- Menambahkan atribut accessor `getIsPdfAttribute()` pada model `Prosedur`, `Regulasi`, dan `Potensi`.
- Menambahkan kolom `mime_type` pada `$fillable` model `Potensi`.

```diff
+if (! function_exists('is_pdf')) {
+    function is_pdf($path = null, $mime = null)
+    {
+        if ($mime && str_contains(strtolower($mime), 'pdf')) {
+            return true;
+        }
+        if ($path) {
+            $extension = strtolower(pathinfo(parse_url($path, PHP_URL_PATH), PATHINFO_EXTENSION));
+            return $extension === 'pdf';
+        }
+        return false;
+    }
+}
```

---

### 4. `database/migrations/2026_09_07_000001_add_mime_type_to_das_potensi_table.php`

**Database — Migrasi Kolom `mime_type` pada Tabel `das_potensi`:**

- Menambahkan kolom `mime_type` (`string`, `nullable`) setelah kolom `file_potensi`.

---

### 5. `app/Http/Requests/PotensiRequest.php` & `app/Http/Controllers/Informasi/PotensiController.php`

**Fix & Feature — Dukungan Upload Dokumen PDF pada Potensi:**

- Mengizinkan tipe berkas PDF pada validasi: `'file_potensi' => 'nullable|file|mimes:jpg,jpeg,png,pdf|max:10240'`.
- Menyimpan nilai MIME type saat berkas diunggah.
- Mengamankan fungsi `download()` menggunakan `resolveSecureFilePath()`.

---

### 6. Controller `ProsedurController.php` & `RegulasiController.php`

**Security & Cleanup:**

- Mengamankan metode `download()` dengan validasi jalur berkas `resolveSecureFilePath()`.
- Menghapus endpoint/metode `preview()` dan variabel `preview_url` pada datatables aksi yang tidak digunakan.

---

### 7. Tampilan Antarmuka (Views)

**UI/UX — Perbaikan Form Upload & Halaman Detail:**

1. **Modul Prosedur:**
   - `show.blade.php`: Merender `<iframe>` responsif untuk berkas PDF dan tag `<img>` untuk berkas gambar.
   - `form_create.blade.php` & `form_edit.blade.php`: Menggunakan `URL.createObjectURL()` untuk pratinjau langsung berkas unggahan secara dinamis.
2. **Modul Regulasi:**
   - `show.blade.php`: Merender `<iframe>` responsif untuk berkas PDF dan tag `<img>` untuk berkas gambar.
   - `form_create.blade.php` & `form_update.blade.php`: Memperbaiki ID duplikat, menampilkan kartu berkas aktif, dan menggunakan `URL.createObjectURL()`.
3. **Modul Potensi:**
   - `show.blade.php` (Admin) & `themes/opendk/default/resources/views/pages/potensi/show.blade.php` (Tema Publik): Menyesuaikan tampilan dokumen PDF via `<iframe>` dan gambar via `<img>`.
   - `form_create.blade.php` & `form_edit.blade.php`: Mengubah label menjadi *"File Potensi (Gambar / Dokumen PDF)"* dan memperbarui skrip pratinjau Blob.
4. **Modul Event & Form Dokumen:**
   - Mengganti `readAsDataURL` dengan `createObjectURL` pada `event/form_create.blade.php` dan `event/form_edit.blade.php`.
   - Mengoreksi ID input pada `form_dokumen/form_edit.blade.php` (`file_dokumen`).

---

### 8. Pengujian Otomatis (Tests)

- `tests/Unit/FilePreviewSecurityTest.php`: Menguji helper `is_pdf`, accessor model, validasi pencegahan Path Traversal, dan header keamanan CSP.
- `tests/Feature/FilePreviewFeatureTest.php`: Menguji render `<iframe>` vs `<img>` pada halaman detail Prosedur, Regulasi, dan Potensi, serta memastikan percobaan Path Traversal pada pengunduhan ditolak dengan respons 404.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Helper `is_pdf()` dan atribut `is_pdf` pada model `Prosedur`, `Regulasi`, dan `Potensi` mengenali berkas PDF dan gambar dengan akurat.
- [x] Pengunggahan berkas PDF pada form tambah/ubah Prosedur, Regulasi, dan Potensi menampilkan pratinjau dokumen / ikon PDF tanpa memicu error broken image.
- [x] Pengunggahan berkas gambar (JPG/PNG) tetap menampilkan pratinjau gambar secara langsung menggunakan Blob URL.
- [x] Halaman rincian (*show*) Prosedur merender `<iframe>` untuk berkas PDF dan `<img>` untuk gambar.
- [x] Halaman rincian (*show*) Regulasi merender `<iframe>` untuk berkas PDF dan `<img>` untuk gambar.
- [x] Halaman rincian (*show*) Potensi pada admin dan tema publik merender `<iframe>` untuk berkas PDF dan `<img>` untuk gambar.
- [x] Header CSP mengizinkan `blob:` pada `object-src` dan `frame-src`, serta menyertakan `frame-ancestors 'self'`.
- [x] Percobaan manipulasi path (*directory traversal*) pada endpoint download berkas ditolak secara aman dengan status 404 Not Found.
- [x] Seluruh automated test (8 tests, 45 assertions) lulus 100%.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

Jalankan perintah berikut di terminal:

```bash
# Menjalankan seluruh pengujian unit keamanan dan deteksi berkas
php artisan test tests/Unit/FilePreviewSecurityTest.php

# Menjalankan seluruh pengujian fitur pratinjau berkas dan unduhan aman
php artisan test tests/Feature/FilePreviewFeatureTest.php
```

---

## 📸 Cara Menjalankan Uji Coba Manual

### 1. Uji Coba Modul Prosedur
1. Masuk ke menu **Informasi > Prosedur** (`/informasi/prosedur`).
2. Klik **Tambah Prosedur**.
3. Pilih berkas PDF pada input berkas.
   - ✅ **Seharusnya:** Area pratinjau langsung menampilkan indikator dokumen PDF dan nama berkas secara rapi tanpa broken image.
4. Simpan data, kemudian buka halaman **Rincian/Detail** prosedur tersebut.
   - ✅ **Seharusnya:** Dokumen PDF tampil di dalam frame penampil dokumen (`<iframe>`) lengkap dengan tombol unduh berkas.

### 2. Uji Coba Modul Regulasi
1. Buka menu **Informasi > Regulasi** (`/informasi/regulasi`).
2. Klik **Tambah Regulasi** dan unggah berkas PDF.
3. Simpan dan buka halaman rincian.
   - ✅ **Seharusnya:** Berkas PDF tampil di dalam `<iframe>` responsif.

### 3. Uji Coba Modul Potensi
1. Buka menu **Informasi > Potensi** (`/informasi/potensi`).
2. Klik **Tambah Potensi**.
3. Unggah berkas dokumen PDF (contoh: profil potensi wilayah).
   - ✅ **Seharusnya:** Form menerima berkas PDF tanpa validasi error.
4. Simpan data dan lihat halaman rincian di panel Admin maupun halaman publik (`/potensi/kategori/{slug}`).
   - ✅ **Seharusnya:** Berkas PDF dapat dibaca langsung melalui penampil dokumen.

### 4. Uji Coba Keamanan Unduhan (Anti Path-Traversal)
1. Coba akses URL pengunduhan dengan parameter manipulasi path, misalnya:
   `/informasi/prosedur/download?file=../../../../etc/passwd` atau `/informasi/potensi/download?file=..%2F..%2F.env`
   - ✅ **Seharusnya:** Sistem merespon dengan `404 Not Found` dan tidak mengembalikan isi berkas sensitif.

---

## 📸 Screenshot atau Video
<img width="1239" height="616" alt="image" src="https://github.com/user-attachments/assets/7fc0be31-c354-4a2c-a2c8-faab6de67ade" />
<img width="760" height="509" alt="image" src="https://github.com/user-attachments/assets/f11edf1c-fc60-4eaf-b380-a24bf41fafd2" />

---

## ⚠️ Catatan Penting

> 1. **Migrasi Database:** PR ini menambahkan kolom `mime_type` pada tabel `das_potensi`. Pastikan untuk menjalankan perintah `php artisan migrate` saat melakukan pembaruan rilis.
> 2. **CSP Compliance:** Penyesuaian direktif CSP memastikan browser modern (Chrome, Firefox, Safari, Edge) dapat merender pratinjau PDF bawaan (*native PDF viewer*) di dalam iframe tanpa melanggar kebijakan keamanan web.
> 3. **Perlu test diserver produksi:** Penyesuaian ini perlu di test di server produksi untuk memastikan perbaikan ini sudah sesuai, karna jika di lokal ini sudah berjalan baik.