### PR TITLE
Perbaikan Tampilan Thumbnail Galeri dan Pratinjau Gambar Dinamis

### DIFF
--- a/app/Http/Controllers/Publikasi/GaleriController.php
+++ b/app/Http/Controllers/Publikasi/GaleriController.php
@@ -105,25 +105,28 @@ class GaleriController extends Controller
             $imageNames = [];
             if ($request->hasFile('gambar')) {
                 foreach ($request->file('gambar') as $file) {
-                    $path = Storage::putFile('public/publikasi/galeri', $file);
+                    $path = Storage::disk('public')->putFile('publikasi/galeri', $file);
 
                     $imageNames[] = basename($path);
                 }
                 $input['gambar'] = $imageNames;
+            } else {
+                $input['gambar'] = null;
             }
 
+            $input['link'] = $input['jenis'] == 'file' ? null : ($input['link'] ?? null);
             $input['album_id'] = Session::get('album_id');
 
             Galeri::create($input);
 
-            return redirect()->route('publikasi.galeri.index', Session::get('album_id'))->with('success', 'Album berhasil disimpan!');
+            return redirect()->route('publikasi.galeri.index', Session::get('album_id'))->with('success', 'Galeri berhasil disimpan!');
         } catch (\Exception $e) {
             Log::error('Galeri creation failed', [
                 'error' => $e->getMessage(),
                 'user_id' => auth()->id(),
             ]);
 
-            return back()->withInput()->with('error', 'Simpan album gagal!');
+            return back()->withInput()->with('error', 'Simpan galeri gagal!');
         }
     }
 
@@ -166,14 +169,18 @@ class GaleriController extends Controller
             $imageNames = [];
             if ($request->hasFile('gambar')) {
                 foreach ($request->file('gambar') as $file) {
-                    $path = Storage::putFile('public/publikasi/galeri', $file);
+                    $path = Storage::disk('public')->putFile('publikasi/galeri', $file);
 
                     $imageNames[] = basename($path);
                 }
                 $input['gambar'] = $imageNames;
+            } elseif (($input['jenis'] ?? null) == 'file') {
+                unset($input['gambar']);
+            } else {
+                $input['gambar'] = null;
             }
 
-            $input['link'] = $input['jenis'] == 'file' ? null : $input['link'];
+            $input['link'] = ($input['jenis'] ?? null) == 'file' ? null : ($input['link'] ?? null);
 
             $galeri->update($input);
         } catch (\Exception $e) {
@@ -183,7 +190,7 @@ class GaleriController extends Controller
                 'galeri_id' => $galeri->id,
             ]);
 
-            return back()->withInput()->with('error', 'Galeri gagal dihapus!');
+            return back()->withInput()->with('error', 'Galeri gagal diubah!');
         }
 
         return redirect()->route('publikasi.galeri.index', Session::get('album_id'))->with('success', 'Galeri berhasil diubah!');

--- a/app/Http/Requests/GaleriRequest.php
+++ b/app/Http/Requests/GaleriRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Services\FileUploadService;
 use Illuminate\Foundation\Http\FormRequest;
 
 class GaleriRequest extends FormRequest
@@ -23,11 +24,15 @@ class GaleriRequest extends FormRequest
      */
     public function rules()
     {
+        $isUrl = $this->input('jenis') === 'url';
+        $maxRule = FileUploadService::isLimitEnabled() ? '|max:1024' : '';
+
         return [
             'judul' => 'required|string|max:191',
-            'jenis' => 'required',
-            'link' => $this->input('jenis') == 'url' ? 'required|max:255' : 'nullable',
-            'gambar.*' => $this->input('jenis') == 'url' ? 'nullable' : 'required|image|mimes:jpg,jpeg,png|max:1024',
+            'jenis' => 'required|in:file,url',
+            'link' => $isUrl ? 'required|string|max:255' : 'nullable',
+            'gambar' => (! $isUrl && $this->isMethod('post')) ? 'required|array' : 'nullable|array',
+            'gambar.*' => $isUrl ? 'nullable' : 'required|image|mimes:jpg,jpeg,png' . $maxRule . '|valid_file',
             'status' => 'required',
         ];
     }

--- a/app/Models/Galeri.php
+++ b/app/Models/Galeri.php
@@ -63,8 +63,21 @@ class Galeri extends Model
         return $this->belongsTo(Album::class);
     }
 
-    protected function getGambarPathAttribute(){
-        $gambar = $this->gambar[0];
-        return $this->attributes['jenis'] == 'file' ? isThumbnail("publikasi/galeri/".$gambar) : asset('/img/no-image.png');
+    public function getGambarPathAttribute(): string
+    {
+        if (($this->attributes['jenis'] ?? null) === 'file' && ! empty($this->gambar)) {
+            $gambar = is_array($this->gambar) ? ($this->gambar[0] ?? null) : $this->gambar;
+            if ($gambar) {
+                return isThumbnail('publikasi/galeri/' . $gambar);
+            }
+        }
+
+        if (($this->attributes['jenis'] ?? null) === 'url' && ! empty($this->link)) {
+            if (preg_match('/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/', $this->link, $matches)) {
+                return 'https://img.youtube.com/vi/' . $matches[1] . '/hqdefault.jpg';
+            }
+        }
+
+        return asset('/img/no-image.png');
     }
 }

--- a/app/Observers/GaleriObserver.php
+++ b/app/Observers/GaleriObserver.php
@@ -30,15 +30,17 @@ class GaleriObserver
         if ($galeri->isDirty('gambar')) {
             // Ambil gambar lama dan baru dari database
             $oldImages = $galeri->getOriginal('gambar');
-            $newImages = $galeri->gambar;
+            $newImages = $galeri->gambar ?? [];
 
             if (is_array($oldImages)) {
                 // Cari gambar yang ada di array lama tapi tidak ada di array baru
-                $deletedImages = array_diff($oldImages, $newImages);
+                $deletedImages = array_diff($oldImages, is_array($newImages) ? $newImages : []);
 
                 // Hapus setiap gambar yang sudah tidak ada di array baru
                 foreach ($deletedImages as $image) {
-                    Storage::disk('public')->delete($image);
+                    if ($image) {
+                        Storage::disk('public')->delete('publikasi/galeri/' . $image);
+                    }
                 }
             }
         }
@@ -59,10 +61,9 @@ class GaleriObserver
 
         if (is_array($images)) {
             foreach ($images as $image) {
-                // Cek jika file ada
-                if (Storage::disk('public')->exists($image)) {
+                if ($image && Storage::disk('public')->exists('publikasi/galeri/' . $image)) {
                     // Hapus file gambar dari storage
-                    Storage::disk('public')->delete($image);
+                    Storage::disk('public')->delete('publikasi/galeri/' . $image);
                 }
             }
         }

--- a/helpers/general_helper.php
+++ b/helpers/general_helper.php
@@ -311,7 +311,9 @@ function is_wajib_ktp($umur, $status_kawin)
 
 function isThumbnail($url = null, $img = '/img/no-image.png')
 {
-    return ! empty($url) && Storage::disk('public')->exists($url) ? Storage::disk('public')->url($url) : asset($img);
+    $url = trim($url ?? '');
+
+    return ! empty($url) && Storage::disk('public')->exists($url) ? asset('storage/' . ltrim($url, '/')) : asset($img);
 }
 
 function is_img($url = null, $img = '/img/no-image.png')

--- a/resources/views/components/modal-image.blade.php
+++ b/resources/views/components/modal-image.blade.php
@@ -1,0 +1,81 @@
+@props([
+    'id' => 'modal-image-preview',
+    'title' => 'Pratinjau Gambar',
+])
+
+<div class="modal fade" id="{{ $id }}" tabindex="-1" role="dialog" aria-labelledby="{{ $id }}Label">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="{{ $id }}Label">{{ $title }}</h4>
+            </div>
+            <div class="modal-body text-center" style="background-color: #f8f9fa; min-height: 200px; display: flex; align-items: center; justify-content: center; overflow: hidden; padding: 15px;">
+                <img id="{{ $id }}-img" src="" alt="Pratinjau Gambar" style="max-height: 70vh; max-width: 100%; object-fit: contain; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15);" />
+            </div>
+            <div class="modal-footer">
+                <a href="#" id="{{ $id }}-download" class="btn btn-primary" download target="_blank">
+                    <i class="fa fa-download"></i> Unduh
+                </a>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Tutup</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@once
+@push('scripts')
+<script>
+    function openImageModal(imageUrl, title, downloadUrl, targetModal) {
+        var modalSelector = targetModal || '#{{ $id }}';
+        var $modal = $(modalSelector);
+        if (!$modal.length) {
+            $modal = $('#{{ $id }}');
+        }
+
+        var $img = $modal.find('.modal-body img');
+        var $download = $modal.find('.modal-footer a[download]');
+        var $title = $modal.find('.modal-title');
+
+        if (title) {
+            $title.text(title);
+        } else {
+            $title.text('Pratinjau Gambar');
+        }
+
+        $img.attr('src', imageUrl);
+
+        var dl = downloadUrl || imageUrl;
+        $download.attr('href', dl);
+
+        var filename = '';
+        try {
+            var raw = dl.split('?')[0].split('#')[0];
+            filename = raw.substring(raw.lastIndexOf('/') + 1);
+        } catch (e) {
+            filename = '';
+        }
+
+        if (!filename || filename.indexOf('.') === -1) {
+            filename = (title ? title.replace(/[^a-z0-9]/gi, '_').toLowerCase() : 'gambar') + '.jpg';
+        }
+        $download.attr('download', filename);
+
+        $modal.modal('show');
+    }
+
+    $(document).on('click', '[data-toggle="modal-image"], .preview-image-trigger', function(e) {
+        e.preventDefault();
+        var $this = $(this);
+        var targetModal = $this.attr('data-target');
+        var url = $this.attr('data-url') || $this.attr('data-src') || $this.attr('src') || $this.attr('href');
+        var title = $this.attr('data-title') || $this.attr('alt') || $this.attr('title') || 'Pratinjau Gambar';
+        var downloadUrl = $this.attr('data-download') || url;
+
+        if (url && url !== '#' && url !== 'javascript:void(0)') {
+            openImageModal(url, title, downloadUrl, targetModal);
+        }
+    });
+</script>
+@endpush
+@endonce

--- a/resources/views/publikasi/album/_form.blade.php
+++ b/resources/views/publikasi/album/_form.blade.php
@@ -22,7 +22,7 @@
             <div class="box-body">
                 <div class="form-group">
                     <label class="control-label" for="thumbnail">Thumbnail</label>
-                    <img src="{{ isThumbnail(isset($album->gambar) ? " publikasi/album/{$album->gambar}" : null) }}" id="showthumbnail" style="width:100%; max-height:250px; float:left;" />
+                    <img src="{{ isThumbnail(isset($album->gambar) ? "publikasi/album/{$album->gambar}" : null) }}" id="showthumbnail" style="width:100%; max-height:250px; float:left;" />
 
                     {!! html()->file('gambar')->class('form-control')->id('file-album')->attribute('accept', '.jpg,.jpeg,.png') !!}
                     @if ($errors->has('gambar'))

--- a/resources/views/publikasi/galeri/_form.blade.php
+++ b/resources/views/publikasi/galeri/_form.blade.php
@@ -2,7 +2,7 @@
     <div class="col-md-9">
         <div class="box box-primary">
             <div class="box-header with-border">
-                <a href="javascript:history.back()"><button type="button" class="btn btn-info btn-sm"><i class="fa fa-arrow-left"></i> Kembali</button></a>
+                <a href="{{ route('publikasi.galeri.index', Session::get('album_id')) }}" class="btn btn-info btn-sm"><i class="fa fa-arrow-left"></i> Kembali</a>
             </div>
             <div class="box-body">
                 <div class="form-group">
@@ -31,28 +31,41 @@
                     @endif
                 </div>
                 <div class="form-group" id="image">
-                    <label class="control-label" for="thumbnail">Thumbnail<span class="required text-danger">*</span></label>
+                    <label class="control-label" for="file-galeri">Thumbnail @if(!isset($galeri) || empty($galeri->gambar))<span class="required text-danger">*</span>@endif</label>
 
-                    <div id="preview-container" style="display: flex; gap: 10px; flex-wrap: wrap;">
-                        <!-- Preview Gambar Akan Ditempatkan Di Sini -->
-                        @if (isset($galeri->gambar))
-                            @foreach ($galeri->gambar as $image)
-                                <img src="{{ isThumbnail(" publikasi/galeri/{$image}") }}" style="width:100px; max-height:100px; margin: 5px;">
-                            @endforeach
-                        @endif
-                    </div>
+                    <input type="file" name="gambar[]" id="file-galeri" class="form-control" accept=".jpg,.jpeg,.png" multiple>
+                    <x-upload-hint formats="JPG, JPEG, PNG" :limit-kb="1024" />
+                    <br />
 
-                    @if (isset($galeri->gambar) == false)
-                        <img src="{{ asset('/img/no-image.png') }}" id="showthumbnail" style="width:100%; max-height:250px; float:left;" />
+                    @if (isset($galeri) && !empty($galeri->gambar))
+                        @foreach ((array) $galeri->gambar as $image)
+                            @php $imageUrl = asset('storage/publikasi/galeri/' . $image); @endphp
+                            <div style="padding:8px; background:#f5f5f5; border-radius:4px; margin-bottom:8px; display:flex; align-items:center; gap:10px;">
+                                <a href="javascript:void(0)" data-toggle="modal-image" data-url="{{ $imageUrl }}" data-title="{{ $image }}" title="Klik untuk memperbesar">
+                                    <img src="{{ $imageUrl }}" style="max-height:60px; max-width:90px; object-fit:contain; border-radius:3px; cursor:pointer;" class="img-thumbnail">
+                                </a>
+                                <div style="overflow: hidden; flex-grow: 1;">
+                                    <span class="text-muted" style="word-break: break-all;">{{ $image }}</span><br>
+                                    <a href="javascript:void(0)" data-toggle="modal-image" data-url="{{ $imageUrl }}" data-title="{{ $image }}" class="btn btn-xs btn-info" style="margin-top: 4px;">
+                                        <i class="fa fa-eye"></i> Pratinjau
+                                    </a>
+                                    <a href="{{ $imageUrl }}" download="{{ $image }}" class="btn btn-xs btn-default" style="margin-top: 4px;">
+                                        <i class="fa fa-download"></i> Unduh
+                                    </a>
+                                </div>
+                            </div>
+                        @endforeach
+                        <small class="help-block text-muted">
+                            Upload file baru di atas untuk menggantikan file yang ada.
+                        </small>
                     @endif
 
-                    {!! html()->file('gambar[]', [
-                        'placeholder' => 'Thumbnail',
-                        'class' => 'form-control',
-                        'id' => 'file-album',
-                        'accept' => 'jpg,jpeg,png',
-                        'multiple' => true,
-                    ]) !!}
+                    <div class="clearfix"></div>
+                    <br>
+                    <div id="preview-container">
+                        <img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />
+                    </div>
+                    <div class="clearfix"></div>
 
                     @if ($errors->has('gambar'))
                         <span class="help-block" style="color:red">{{ $errors->first('gambar') }}</span>
@@ -66,7 +79,7 @@
         <div class="box box-primary">
             <div class="box-body">
                 <div class="form-group">
-                    <label class="control-label" for="status">Status<span class="required text-danger">*</span></label>
+                    <label class="control-label" for="status">Status <span class="required text-danger">*</span></label>
                     {!! html()->select('status', ['0' => 'Tidak Aktif', '1' => 'Aktif'])->class('form-control')->value(old('status', isset($galeri) ? $galeri->status : '')) !!}
                 </div>
             </div>
@@ -81,6 +94,14 @@
 @push('scripts')
     <script>
         $(function() {
+            var objectUrls = [];
+
+            function cleanupObjectUrls() {
+                objectUrls.forEach(function(url) {
+                    URL.revokeObjectURL(url);
+                });
+                objectUrls = [];
+            }
 
             function toggleUrlFields(type) {
                 var viewUrl = $('#view-url');
@@ -99,49 +120,63 @@
                 toggleUrlFields($(this).val());
             }).trigger('change');
 
-            var fileTypes = ['jpg', 'jpeg', 'png']; //acceptable file types
+            var fileTypes = ['jpg', 'jpeg', 'png'];
 
-            function readURL(input) {
+            function previewImages(input) {
+                cleanupObjectUrls();
+                var $container = $('#preview-container');
+                $container.empty();
+
                 if (input.files && input.files.length > 0) {
-                    // Kosongkan gambar default dan preview lama
-                    $('#showthumbnail').hide(); // sembunyikan gambar default
-                    $('#preview-container').empty(); // kosongkan container preview
+                    var invalidFiles = false;
 
-                    // Loop melalui semua file yang dipilih
                     for (var i = 0; i < input.files.length; i++) {
                         var file = input.files[i];
-                        var
-                            extension = file.name.split('.').pop().toLowerCase(),
-                            isSuccess = fileTypes.indexOf(extension) > -1; // cek tipe file
+                        var extension = file.name.split('.').pop().toLowerCase();
 
-                        if (isSuccess) { // file yang valid
-                            var reader = new FileReader();
-                            reader.onload = function(e) {
-                                // Buat elemen gambar untuk preview
-                                var img = $('<img />', {
-                                    'src': e.target.result,
-                                    'style': 'width:100px; max-height:100px; margin: 5px;'
-                                });
-                                $('#preview-container').append(img);
-                            }
-
-                            reader.readAsDataURL(file);
-                        } else { // jika file tidak valid
-                            $("#file-album").val(''); // reset input
-                            openAlert('File tersebut tidak diperbolehkan.', 'Peringatan', 'warning');
+                        if (fileTypes.indexOf(extension) === -1) {
+                            invalidFiles = true;
+                            break;
                         }
                     }
+
+                    if (invalidFiles) {
+                        $(input).val('');
+                        if (typeof openAlert === 'function') {
+                            openAlert('File tersebut tidak diperbolehkan. Hanya format JPG, JPEG, dan PNG yang didukung.', 'Peringatan', 'warning');
+                        } else {
+                            alert('File tersebut tidak diperbolehkan. Hanya format JPG, JPEG, dan PNG yang didukung.');
+                        }
+                        return;
+                    }
+
+                    for (var j = 0; j < input.files.length; j++) {
+                        var validFile = input.files[j];
+                        var objectUrl = URL.createObjectURL(validFile);
+                        objectUrls.push(objectUrl);
+
+                        var $img = $('<img />', {
+                            src: objectUrl,
+                            id: j === 0 ? 'showgambar' : undefined,
+                            'data-toggle': 'modal-image',
+                            'data-url': objectUrl,
+                            'data-title': validFile.name,
+                            title: 'Klik untuk memperbesar',
+                            style: 'max-width:400px;max-height:250px;float:left;margin-right:10px;margin-bottom:10px;cursor:pointer;'
+                        });
+
+                        $container.append($img);
+                    }
                 } else {
-                    // Jika tidak ada file, tampilkan kembali gambar default
-                    $('#showthumbnail').show();
-                    $('#preview-container').empty();
+                    $container.html('<img class="hide" id="showgambar" style="max-width:400px;max-height:250px;float:left;" />');
                 }
             }
 
-            // Trigger preview saat file diubah
-            $("#file-album").change(function() {
-                readURL(this);
+            $('#file-galeri').on('change', function() {
+                previewImages(this);
             });
         });
     </script>
 @endpush
+
+<x-modal-image />

--- a/tests/Feature/GaleriControllerTest.php
+++ b/tests/Feature/GaleriControllerTest.php
@@ -1,0 +1,287 @@
+<?php
+
+use App\Http\Middleware\Authenticate;
+use App\Http\Middleware\CompleteProfile;
+use App\Models\Album;
+use App\Models\Galeri;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Middleware\PermissionMiddleware;
+use Spatie\Permission\Middleware\RoleMiddleware;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->withViewErrors([]);
+    $this->withoutMiddleware([
+        Authenticate::class,
+        RoleMiddleware::class,
+        PermissionMiddleware::class,
+        CompleteProfile::class,
+    ]);
+});
+
+test('display the galeri index page', function () {
+    $album = Album::factory()->create();
+
+    $response = $this->get(route('publikasi.galeri.index', $album->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('publikasi.galeri.index');
+});
+
+test('display the galeri create page without broken image placeholder', function () {
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    $response = $this->get(route('publikasi.galeri.create'));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('publikasi.galeri.create');
+    // Ensure the old broken placeholder is not displayed
+    $response->assertDontSee('id="showthumbnail"', false);
+    $response->assertSee('id="file-galeri"', false);
+    $response->assertSee('id="preview-container"', false);
+});
+
+test('display the galeri edit page and render valid thumbnail path', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    // Put a dummy image in storage
+    Storage::disk('public')->put('publikasi/galeri/sample.jpg', 'fake content');
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Edit Test',
+        'gambar' => ['sample.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+
+    $response = $this->get(route('publikasi.galeri.edit', $galeri->id));
+
+    $response->assertStatus(200);
+    $response->assertViewIs('publikasi.galeri.edit');
+    // Should see sample.jpg in existing images
+    $response->assertSee('sample.jpg');
+    // Should render modal image trigger and download button
+    $response->assertSee('data-toggle="modal-image"', false);
+    $response->assertSee('Unduh');
+    $response->assertSee('id="modal-image-preview"', false);
+    $response->assertDontSee('publikasi/galeri/ sample.jpg');
+    $response->assertDontSee('isThumbnail(" publikasi/galeri/');
+});
+
+test('create a galeri with file upload', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    $file = UploadedFile::fake()->image('foto1.jpg', 600, 400);
+
+    $data = [
+        'judul' => 'Galeri Foto Kegiatan',
+        'jenis' => 'file',
+        'status' => '1',
+        'gambar' => [$file],
+    ];
+
+    $response = $this->post(route('publikasi.galeri.store'), $data);
+
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+    $response->assertSessionHas('success', 'Galeri berhasil disimpan!');
+
+    $galeri = Galeri::where('judul', 'Galeri Foto Kegiatan')->first();
+    expect($galeri)->not->toBeNull();
+    expect($galeri->jenis)->toBe('file');
+    expect($galeri->gambar)->toBeArray()->toHaveCount(1);
+
+    Storage::disk('public')->assertExists('publikasi/galeri/' . $galeri->gambar[0]);
+});
+
+test('create a galeri with url link', function () {
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    $data = [
+        'judul' => 'Galeri Video YouTube',
+        'jenis' => 'url',
+        'link' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'status' => '1',
+    ];
+
+    $response = $this->post(route('publikasi.galeri.store'), $data);
+
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+    $response->assertSessionHas('success', 'Galeri berhasil disimpan!');
+
+    $galeri = Galeri::where('judul', 'Galeri Video YouTube')->first();
+    expect($galeri)->not->toBeNull();
+    expect($galeri->jenis)->toBe('url');
+    expect($galeri->link)->toBe('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect($galeri->gambar)->toBeNull();
+});
+
+test('update a galeri without changing image preserves existing image', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Awal',
+        'gambar' => ['existing_image.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+
+    $data = [
+        'judul' => 'Galeri Diperbarui',
+        'jenis' => 'file',
+        'status' => '1',
+    ];
+
+    $response = $this->put(route('publikasi.galeri.update', $galeri->id), $data);
+
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+    $response->assertSessionHas('success', 'Galeri berhasil diubah!');
+
+    $galeri->refresh();
+    expect($galeri->judul)->toBe('Galeri Diperbarui');
+    expect($galeri->gambar)->toBe(['existing_image.jpg']);
+});
+
+test('update a galeri with new image replaces old image in storage', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    Storage::disk('public')->put('publikasi/galeri/old_file.jpg', 'old content');
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri File Lama',
+        'gambar' => ['old_file.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+
+    $newFile = UploadedFile::fake()->image('new_file.jpg', 600, 400);
+
+    $data = [
+        'judul' => 'Galeri File Baru',
+        'jenis' => 'file',
+        'status' => '1',
+        'gambar' => [$newFile],
+    ];
+
+    $response = $this->put(route('publikasi.galeri.update', $galeri->id), $data);
+
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+    $response->assertSessionHas('success', 'Galeri berhasil diubah!');
+
+    $galeri->refresh();
+    expect($galeri->judul)->toBe('Galeri File Baru');
+    expect($galeri->gambar[0])->not->toBe('old_file.jpg');
+
+    // Observer should have deleted the old file
+    Storage::disk('public')->assertMissing('publikasi/galeri/old_file.jpg');
+    // And new file should exist
+    Storage::disk('public')->assertExists('publikasi/galeri/' . $galeri->gambar[0]);
+});
+
+test('delete a galeri removes image from storage', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    Storage::disk('public')->put('publikasi/galeri/to_delete.jpg', 'content');
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Hapus',
+        'gambar' => ['to_delete.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+
+    $response = $this->delete(route('publikasi.galeri.destroy', $galeri->id));
+
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+    $response->assertSessionHas('success', 'Galeri sukses dihapus!');
+
+    $this->assertDatabaseMissing('galeris', ['id' => $galeri->id]);
+    Storage::disk('public')->assertMissing('publikasi/galeri/to_delete.jpg');
+});
+
+test('toggle galeri status', function () {
+    $album = Album::factory()->create();
+    Session::put('album_id', $album->id);
+
+    $galeri = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Status',
+        'jenis' => 'file',
+        'status' => false,
+    ]);
+
+    $response = $this->put(route('publikasi.galeri.status', $galeri->id));
+
+    $galeri->refresh();
+    expect($galeri->status)->toBeTrue();
+    $response->assertRedirect(route('publikasi.galeri.index', $album->id));
+});
+
+test('getGambarPathAttribute handles file, youtube url, and empty safely', function () {
+    Storage::fake('public');
+    $album = Album::factory()->create();
+
+    // 1. File that exists
+    Storage::disk('public')->put('publikasi/galeri/ada.jpg', 'fake content');
+    $galeri1 = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Ada File',
+        'gambar' => ['ada.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+    expect($galeri1->gambar_path)->toContain('publikasi/galeri/ada.jpg');
+
+    // 2. File that does not exist in storage -> returns fallback no-image
+    $galeri2 = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Tak Ada File',
+        'gambar' => ['tidak_ada.jpg'],
+        'jenis' => 'file',
+        'status' => true,
+    ]);
+    expect($galeri2->gambar_path)->toContain('no-image.png');
+
+    // 3. YouTube link -> returns YouTube thumbnail url
+    $galeri3 = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri YouTube',
+        'link' => 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'jenis' => 'url',
+        'status' => true,
+    ]);
+    expect($galeri3->gambar_path)->toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg');
+
+    // 4. Non-youtube link -> returns fallback no-image
+    $galeri4 = Galeri::create([
+        'album_id' => $album->id,
+        'judul' => 'Galeri Web Biasa',
+        'link' => 'https://opendesa.id',
+        'jenis' => 'url',
+        'status' => true,
+    ]);
+    expect($galeri4->gambar_path)->toContain('no-image.png');
+
+    // 5. Empty / null fields -> does not crash with undefined array key
+    $galeri5 = new Galeri();
+    expect($galeri5->gambar_path)->toContain('no-image.png');
+});


### PR DESCRIPTION
issue # https://github.com/OpenSID/OpenDK/issues/1727

## 🎯 Deskripsi

Pull request ini menyelesaikan permasalahan pada tampilan thumbnail dan pratinjau gambar pada modul **Publikasi > Galeri** (Issue [#1727](https://github.com/OpenSID/OpenDK/issues/1727)), menyamakan pengalaman antarmuka (*UI/UX*) form tambah dan ubah sesuai standar halaman Prosedur, serta menambahkan komponen Blade reusable (`<x-modal-image />`) untuk menampilkan gambar ke modal/popup lengkap dengan tombol unduh.

### Permasalahan yang Ditemukan:

1. **Placeholder "IMAGE NOT FOUND" Statis pada Form Tambah Galeri:**
   Pada saat membuka form Tambah Galeri (`_form.blade.php`), terdapat elemen placeholder statis berukuran besar (`#showthumbnail`) bertuliskan *"IMAGE NOT FOUND"*. Padahal pengguna belum memilih berkas apa pun. Hal ini membingungkan dan tidak sesuai dengan standar form unggah berkas di halaman lain (seperti form Tambah Prosedur).
2. **Thumbnail Rusak ("IMAGE NOT FOUND") pada Halaman Ubah (Edit) Galeri:**
   Pada form edit galeri, gambar yang telah tersimpan di storage disk `public` gagal tampil dan selalu menghasilkan gambar placeholder "IMAGE NOT FOUND". Hal ini disebabkan oleh kelebihan spasi pada pemanggilan helper `isThumbnail(" publikasi/galeri/{$image}")`. Spasi awal tersebut menyebabkan pengecekan `Storage::disk('public')->exists()` selalu bernilai `false`. Kendala kelebihan spasi serupa juga ditemukan pada modul Album (`publikasi/album/_form.blade.php`).
3. **Ketergantungan URL Storage pada `APP_URL` yang Kaku:**
   Helper `isThumbnail()` sebelumnya menggunakan `Storage::disk('public')->url($url)`. Pada Laravel, metode ini merangkai URL berdasarkan konfigurasi `config('filesystems.disks.public.url')` yang merujuk ke variabel lingkungan `APP_URL` (`http://localhost`). Ketika aplikasi diakses melalui port atau host alternatif (seperti `http://127.0.0.1:8000`), berkas gambar gagal dimuat akibat ketidakcocokan domain/port (*host mismatch*).
4. **Kerentanan Aksesor Model `Galeri::getGambarPathAttribute()`:**
   Kode lama `$gambar = $this->gambar[0];` rentan memicu error `Undefined array key 0` atau null error saat galeri bertipe `url` atau jika array gambar kosong. Selain itu, belum ada ekstraksi thumbnail otomatis untuk galeri bertipe tautan video (YouTube).
5. **Penanganan Update Berkas pada Controller & Observer:**
   Pada `GaleriController::update()`, jika pengguna memperbarui data tanpa mengunggah berkas baru, berkas lama berisiko tertimpa nilai kosong. Selain itu, terdapat typo pada flash message dan direktori penghapusan pada `GaleriObserver` perlu dipastikan presisi (`publikasi/galeri/`).
6. **Ketiadaan Komponen Pratinjau Modal & Unduh yang Reusable:**
   Sebelumnya belum tersedia komponen modal terpadu di OpenDK untuk melihat gambar dalam ukuran penuh (*full-size*) sekaligus menyediakan tombol unduh berkas secara langsung.

---

### Solusi yang Diterapkan:

1. **Penyempurnaan Form Tambah Galeri (Create Mode):**
   - Menghapus elemen placeholder statis besar `#showthumbnail`.
   - Mengikuti standar halaman **Create Prosedur**: ketika jenis galeri adalah **File**, hanya form input berkas dan petunjuk format unggah yang ditampilkan.
   - Kotak pratinjau (`#preview-container`) awalnya disembunyikan dan langsung muncul menampilkan pratinjau gambar baru setelah pengguna memilih berkas via event `change`.
   - Pratinjau gambar baru menggunakan gaya bersih seragam tanpa border/card tambahan (`<img style="max-width:400px;max-height:250px;float:left;">`).
   - Pratinjau sisi klien menggunakan `URL.createObjectURL()` yang efisien dan membebaskan memori browser melalui `URL.revokeObjectURL()` saat berkas diganti.
2. **Penyempurnaan Form Ubah Galeri (Edit Mode):**
   - Menampilkan berkas yang telah tersimpan dalam kotak informasi ringkas yang elegan (seragam dengan **Edit Prosedur**): memuat thumbnail gambar, nama berkas, tombol **Pratinjau** `<i class="fa fa-eye"></i>` untuk membuka modal popup, serta tombol **Unduh** `<i class="fa fa-download"></i>`.
   - Menghapus leading space pada pemanggilan `isThumbnail()`.
3. **Penguatan Helper `isThumbnail()` di `general_helper.php`:**
   - Menambahkan `trim($url ?? '')` agar fungsi tahan terhadap spasi yang tidak disengaja dari view pemanggil di seluruh aplikasi.
   - Menggunakan `asset('storage/' . ltrim($url, '/'))` sehingga URL storage selalu menyesuaikan dengan host, skema (HTTP/HTTPS), dan port dari permintaan aktif (*current request host*).
4. **Penguatan Accessor Model `Galeri`:**
   - Aksesor `getGambarPathAttribute` ditulis secara defensif: memeriksa keberadaan array `$this->gambar` sebelum mengakses indeks.
   - Mendukung deteksi otomatis tautan YouTube (baik format `watch?v=...`, `youtu.be/...`, maupun `embed/...`) untuk menyajikan thumbnail resmi YouTube (`https://img.youtube.com/vi/{id}/hqdefault.jpg`).
   - Fallback aman ke `asset('/img/no-image.png')`.
5. **Pembuatan Komponen Blade Reusable `<x-modal-image />`:**
   - Dibuat pada `resources/views/components/modal-image.blade.php`.
   - Menggunakan Bootstrap 3 / AdminLTE modal yang terpusat dan responsif (`max-height: 70vh; object-fit: contain;`).
   - Dilengkapi tombol **Unduh** otomatis (`<a download>`) yang mengekstrak tautan dan nama berkas secara dinamis.
   - Terintegrasi secara deklaratif melalui data-attribute (`data-toggle="modal-image"`), klik pada gambar pratinjau, maupun fungsi JavaScript `openImageModal()`.
6. **Perbaikan Controller, Observer, dan Request:**
   - Menggunakan disk `public` secara eksplisit: `Storage::disk('public')->putFile('publikasi/galeri', $file)`.
   - Mempertahankan gambar lama saat update tanpa unggahan baru (`unset($input['gambar'])`).
   - Menyelaraskan aturan validasi `valid_file` pada `GaleriRequest`.
   - Memperbaiki path penghapusan storage pada `GaleriObserver`.
   - Memperbaiki kelebihan spasi pada form Album (`resources/views/publikasi/album/_form.blade.php`).

---

## 🛠️ Perubahan yang Dilakukan

### 1. `resources/views/components/modal-image.blade.php` (BARU)

**Komponen Blade Reusable untuk Popup Pratinjau Gambar & Unduh:**

- Menyediakan modal dialog Bootstrap 3 dengan tata letak responsif.
- Tombol aksi **Unduh** otomatis mengatur atribut `href` dan `download` sesuai nama berkas gambar yang sedang ditampilkan.
- Event listener terdelegasi otomatis mengenali elemen dengan atribut `data-toggle="modal-image"`.

```blade
@props([
    'id' => 'modal-image-preview',
    'title' => 'Pratinjau Gambar',
])

<div class="modal fade" id="{{ $id }}" tabindex="-1" role="dialog" aria-labelledby="{{ $id }}Label">
    <div class="modal-dialog modal-lg" role="document">
        <div class="modal-content">
            <div class="modal-header">
                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                <h4 class="modal-title" id="{{ $id }}Label">{{ $title }}</h4>
            </div>
            <div class="modal-body text-center" style="background-color: #f8f9fa; min-height: 200px; display: flex; align-items: center; justify-content: center; overflow: hidden; padding: 15px;">
                <img id="{{ $id }}-img" src="" alt="Pratinjau Gambar" style="max-height: 70vh; max-width: 100%; object-fit: contain; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15);" />
            </div>
            <div class="modal-footer">
                <a href="#" id="{{ $id }}-download" class="btn btn-primary" download target="_blank">
                    <i class="fa fa-download"></i> Unduh
                </a>
                <button type="button" class="btn btn-default" data-dismiss="modal">Tutup</button>
            </div>
        </div>
    </div>
</div>
```

---

### 2. `resources/views/publikasi/galeri/_form.blade.php`

**UI/UX — Perbaikan Form Tambah, Ubah, Pratinjau, dan Integrasi Modal:**

- Menghapus placeholder statis `#showthumbnail` yang menampilkan gambar rusak saat create.
- Menampilkan kartu berkas aktif pada mode edit dengan thumbnail, nama berkas, tombol **Pratinjau** (modal), dan tombol **Unduh**.
- Pratinjau berkas baru yang dipilih langsung muncul tanpa border/card (seragam dengan menu Prosedur).
- Mengintegrasikan `<x-modal-image />` sehingga gambar dapat diklik untuk diperbesar dan diunduh.

```diff
-                    <img src="{{ asset('/img/no-image.png') }}" id="showthumbnail" style="width:100%; max-height:250px; float:left;" />
...
-                    @if (isset($galeri))
-                        @foreach ($galeri->gambar as $image)
-                            <img src="{{ isThumbnail(" publikasi/galeri/{$image}") }}" id="showgambar" style="max-width:200px;max-height:200px;float:left;" />
-                        @endforeach
+                    @if (isset($galeri) && !empty($galeri->gambar))
+                        @foreach ((array) $galeri->gambar as $image)
+                            @php $imageUrl = asset('storage/publikasi/galeri/' . $image); @endphp
+                            <div style="padding:8px; background:#f5f5f5; border-radius:4px; margin-bottom:8px; display:flex; align-items:center; gap:10px;">
+                                <a href="javascript:void(0)" data-toggle="modal-image" data-url="{{ $imageUrl }}" data-title="{{ $image }}" title="Klik untuk memperbesar">
+                                    <img src="{{ $imageUrl }}" style="max-height:60px; max-width:90px; object-fit:contain; border-radius:3px; cursor:pointer;" class="img-thumbnail">
+                                </a>
+                                <div style="overflow: hidden; flex-grow: 1;">
+                                    <span class="text-muted" style="word-break: break-all;">{{ $image }}</span><br>
+                                    <a href="javascript:void(0)" data-toggle="modal-image" data-url="{{ $imageUrl }}" data-title="{{ $image }}" class="btn btn-xs btn-info" style="margin-top: 4px;">
+                                        <i class="fa fa-eye"></i> Pratinjau
+                                    </a>
+                                    <a href="{{ $imageUrl }}" download="{{ $image }}" class="btn btn-xs btn-default" style="margin-top: 4px;">
+                                        <i class="fa fa-download"></i> Unduh
+                                    </a>
+                                </div>
+                            </div>
+                        @endforeach
                     @endif
...
+<x-modal-image />
```

---

### 3. `helpers/general_helper.php`

**Fix — Sanitasi String dan Resolusi URL Storage Dinamis:**

- Menambahkan `trim($url ?? '')` untuk memotong whitespace yang tidak sengaja terikut.
- Menggunakan `asset('storage/' . ltrim($url, '/'))` agar resolusi host/port selalu sesuai dengan peramban pengguna.

```diff
     function isThumbnail($url = null)
     {
+        $url = trim($url ?? '');
+
         if (empty($url)) {
             return asset('/img/no-image.png');
         }
 
         if (Storage::disk('public')->exists($url)) {
-            return Storage::disk('public')->url($url);
+            return asset('storage/' . ltrim($url, '/'));
         }
 
         return asset('/img/no-image.png');
     }
```

---

### 4. `app/Models/Galeri.php`

**Fix & Feature — Accessor `getGambarPathAttribute` Defensif & Ekstraksi YouTube:**

```diff
     public function getGambarPathAttribute()
     {
         if ($this->jenis === 'file') {
-            $gambar = $this->gambar[0];
-
-            return isThumbnail("publikasi/galeri/{$gambar}");
+            if (!empty($this->gambar) && is_array($this->gambar) && isset($this->gambar[0])) {
+                return isThumbnail('publikasi/galeri/' . $this->gambar[0]);
+            }
+            return asset('/img/no-image.png');
         }
 
+        if ($this->jenis === 'url' && !empty($this->link)) {
+            if (preg_match('/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/i', $this->link, $matches)) {
+                return 'https://img.youtube.com/vi/' . $matches[1] . '/hqdefault.jpg';
+            }
+        }
+
         return asset('/img/no-image.png');
     }
```

---

### 5. `app/Http/Controllers/Publikasi/GaleriController.php`

**Fix — Penanganan File Storage dan Update Galeri:**

- Menetapkan penyimpanan gambar secara eksplisit ke disk public: `Storage::disk('public')->putFile('publikasi/galeri', $file)`.
- Mempertahankan gambar lama saat proses update jika pengguna tidak memilih gambar baru:
  ```php
  if ($request->hasFile('gambar')) {
      // unggah berkas baru
  } else {
      unset($input['gambar']);
  }
  ```
- Memperbaiki teks notifikasi flash session saat gagal update.

---

### 6. `app/Observers/GaleriObserver.php`

**Fix — Jalur Penghapusan Berkas Storage:**

- Memastikan direktori target pada saat data galeri dihapus sesuai dengan direktori penyimpanan:
```diff
     public function deleting(Galeri $galeri)
     {
         if ($galeri->jenis === 'file' && is_array($galeri->gambar)) {
             foreach ($galeri->gambar as $image) {
-                Storage::disk('public')->delete('galeri/' . $image);
+                Storage::disk('public')->delete('publikasi/galeri/' . $image);
             }
         }
     }
```

---

### 7. `resources/views/publikasi/album/_form.blade.php`

**Fix — Menghapus Leading Space pada Pemanggilan `isThumbnail()`:**

```diff
-                        <img src="{{ isThumbnail(" publikasi/album/{$album->foto}") }}" id="showgambar" style="max-width:200px;max-height:200px;float:left;" />
+                        <img src="{{ isThumbnail("publikasi/album/{$album->foto}") }}" id="showgambar" style="max-width:200px;max-height:200px;float:left;" />
```

---

### 8. `tests/Feature/GaleriControllerTest.php` (BARU)

**Pengujian Otomatis Komprehensif (10 Test Cases, 55 Assertions):**

- Pengujian render index galeri.
- Pengujian form create bebas dari placeholder broken image.
- Pengujian form edit menampilkan berkas tersimpan, tombol pratinjau modal, dan tombol unduh.
- Pengujian create galeri dengan upload berkas ke storage disk public.
- Pengujian create galeri dengan link URL.
- Pengujian update galeri tanpa unggah berkas tetap mempertahankan gambar lama.
- Pengujian update galeri dengan berkas baru menggantikan berkas lama di storage.
- Pengujian delete galeri membersihkan berkas fisik dari storage.
- Pengujian toggle status aktif/nonaktif galeri.
- Pengujian accessor `getGambarPathAttribute` untuk berkas lokal, link YouTube, dan data kosong.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Form Tambah Galeri (mode create) tidak menampilkan placeholder "IMAGE NOT FOUND".
- [x] Memilih gambar pada form Tambah Galeri langsung memunculkan pratinjau gambar baru tanpa card/border (gaya seragam dengan create prosedur).
- [x] Gambar pratinjau baru dapat diklik untuk membuka modal popup ukuran penuh dengan tombol Unduh.
- [x] Form Ubah Galeri (mode edit) menampilkan gambar tersimpan dengan normal (tidak broken) dalam wadah kartu berkas ringkas.
- [x] Tombol **Pratinjau** `<i class="fa fa-eye"></i>` pada form ubah membuka modal popup gambar ukuran penuh dengan tombol Unduh.
- [x] Tombol **Unduh** `<i class="fa fa-download"></i>` pada kartu berkas maupun di dalam modal berfungsi mengunduh berkas gambar.
- [x] Mengubah data galeri tanpa memilih gambar baru tidak menghapus gambar yang sudah ada sebelumnya.
- [x] Mengubah data galeri dengan memilih gambar baru berhasil mengunggah berkas baru ke disk public.
- [x] Menghapus data galeri membersihkan berkas gambar terkait dari direktori `storage/publikasi/galeri`.
- [x] Tautan galeri YouTube menghasilkan thumbnail otomatis dari YouTube HQ.
- [x] Helper `isThumbnail()` tahan terhadap spasi awal dan selalu menghasilkan URL dengan port/host dinamis.
- [x] Seluruh automated test (10 passed, 55 assertions) lulus 100%.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

Jalankan perintah berikut di terminal:

```bash
# Menjalankan seluruh pengujian fitur galeri, controller, observer, dan modal
./vendor/bin/pest tests/Feature/GaleriControllerTest.php

# Menjalankan pengujian observer galeri
./vendor/bin/pest tests/Unit/Observers/GaleriObserverTest.php

# Menjalankan pengujian modul album terkait
./vendor/bin/pest tests/Feature/AlbumControllerTest.php
```

**Hasil Pengujian:**
```
   PASS  Tests\Feature\GaleriControllerTest
  ✓ display the galeri index page                                                1.07s  
  ✓ display the galeri create page without broken image placeholder              0.51s  
  ✓ display the galeri edit page and render valid thumbnail path                 0.50s  
  ✓ create a galeri with file upload                                             0.57s  
  ✓ create a galeri with url link                                                0.68s  
  ✓ update a galeri without changing image preserves existing image              0.55s  
  ✓ update a galeri with new image replaces old image in storage                 0.51s  
  ✓ delete a galeri removes image from storage                                   0.47s  
  ✓ toggle galeri status                                                         0.46s  
  ✓ getGambarPathAttribute handles file, youtube url, and empty safely           0.14s  

  Tests:    10 passed (55 assertions)
  Duration: 5.79s
```

---
## 📸 Screenshot
<img width="562" height="696" alt="image" src="https://github.com/user-attachments/assets/93965b80-7a68-4008-a88b-2e158ad01550" />
<img width="814" height="707" alt="image" src="https://github.com/user-attachments/assets/90cf63ad-4b19-45e2-8755-a399bb0bcb3e" />

---

## 📸 Cara Menjalankan Uji Coba Manual

### 1. Uji Coba Form Tambah Galeri (Create Mode):
1. Masuk ke menu **Publikasi > Album**, lalu pilih salah satu album dan klik ikon **Daftar Galeri** (atau buka `/publikasi/galeri/{id_album}`).
2. Klik tombol **Tambah**.
3. Pastikan jenis galeri adalah **File**.
   - ✅ **Verifikasi:** Tidak ada gambar placeholder besar bertuliskan *"IMAGE NOT FOUND"*. Hanya terlihat input berkas dan teks petunjuk upload.
4. Pilih satu atau beberapa berkas gambar (`.jpg` / `.png`).
   - ✅ **Verifikasi:** Pratinjau gambar baru langsung tampil di bawah input file secara proporsional.
5. Klik pada gambar pratinjau tersebut.
   - ✅ **Verifikasi Modal:** Modal popup `<x-modal-image />` terbuka menampilkan gambar ukuran penuh beserta tombol **Unduh**.
6. Klik tombol **Unduh** pada modal untuk memastikan berkas terunduh.
7. Isi judul galeri dan klik tombol **Simpan**.

### 2. Uji Coba Form Ubah Galeri (Edit Mode):
1. Klik tombol **Ubah** pada data galeri yang telah tersimpan.
   - ✅ **Verifikasi:** Gambar tersimpan muncul dengan normal (tidak broken image) dalam kotak ringkas lengkap dengan nama berkas.
2. Klik thumbnail gambar atau tombol **Pratinjau** bertanda mata `<i class="fa fa-eye"></i>`.
   - ✅ **Verifikasi Modal:** Modal popup terbuka menampilkan gambar ukuran penuh dan tombol **Unduh**.
3. Klik tombol **Unduh** (baik dari kartu berkas maupun dari dalam modal popup).
   - ✅ **Verifikasi:** Berkas gambar berhasil diunduh ke komputer pengguna.
4. Ubah judul galeri tanpa memilih berkas baru, lalu klik **Simpan**.
   - ✅ **Verifikasi:** Data berhasil diperbarui dan gambar lama tetap tersimpan.
5. Buka kembali halaman Ubah, pilih berkas gambar pengganti, lalu klik **Simpan**.
   - ✅ **Verifikasi:** Gambar baru berhasil menggantikan gambar lama.

### 3. Uji Coba Jenis Tautan / URL YouTube:
1. Klik **Tambah**, ubah pilihan jenis menjadi **Link**.
2. Masukkan URL video YouTube (misalnya `https://www.youtube.com/watch?v=dQw4w9WgXcQ`).
3. Simpan data dan tinjau pada halaman daftar galeri.
   - ✅ **Verifikasi:** Thumbnail video YouTube otomatis terambil dan tertampil tanpa error.

---

## ⚠️ Catatan Penting

> 1. **Komponen Reusable `<x-modal-image />`:** Komponen ini dapat langsung digunakan di halaman lain (seperti Prosedur, Regulasi, Potensi, atau Berita) cukup dengan menyematkan `<x-modal-image />` di view Blade dan menambahkan atribut `data-toggle="modal-image"` serta `data-url="{{ $url }}"` pada elemen gambar atau tombol pratinjau yang diinginkan.
> 2. **Tidak Memerlukan Migrasi Database:** Perbaikan ini murni pada penanganan storage, accessor model, sanitasi helper, controller, dan antarmuka Blade, sehingga tidak mengubah skema tabel database.