### PR TITLE
Fix: Tambah/edit ketua lembaga dan anggota saat menggunakan database gabungan (API Satu Data)

### DIFF
--- a/app/Http/Controllers/Data/LembagaAnggotaController.php
+++ b/app/Http/Controllers/Data/LembagaAnggotaController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\Data;
 
+use App\Models\SettingAplikasi;
 use Carbon\Carbon;
 use App\Models\Lembaga;
 use App\Models\Penduduk;
 use Illuminate\Http\Request;
 use App\Models\LembagaAnggota;
+use App\Services\PendudukService;
 use Yajra\DataTables\DataTables;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreLembagaAnggotaRequest;
@@ -38,17 +40,23 @@ class LembagaAnggotaController extends Controller
         if ($request->ajax()) {
             $lembaga = Lembaga::where('slug', $slug)->firstOrFail();
 
-            // Ambil data anggota lembaga dengan informasi lembaga dan penduduk terkait
             $anggotaList = LembagaAnggota::with(['lembaga', 'penduduk'])
                 ->where('lembaga_id', $lembaga->id)
                 ->get();
 
+            $pendudukGabunganIds = $anggotaList->pluck('penduduk_id_gabungan')->filter()->unique()->values()->all();
+
+            $pendudukGabungan = collect();
+            if ($this->isDatabaseGabungan() && !empty($pendudukGabunganIds)) {
+                $pendudukGabungan = (new PendudukService())->pendudukGabunganByIds($pendudukGabunganIds);
+            }
+            
             return DataTables::of($anggotaList)
                 ->addIndexColumn()
                 ->addColumn('aksi', function ($row) use ($slug) {
                     if (!auth()->guest()) {
-                        $data['edit_url'] = auth()->user()->can('access.data.lembaga_anggota.edit') ? route('data.lembaga_anggota.edit', ['slug' => $slug, 'id' => $row->id]) : null;
-                        $data['delete_url'] = auth()->user()->can('access.data.lembaga_anggota.delete') ? route('data.lembaga_anggota.destroy', ['slug' => $slug, 'id' => $row->id]) : null;
+                        $data['edit_url'] = auth()->user()->can('access.data.lembaga.edit') ? route('data.lembaga_anggota.edit', ['slug' => $slug, 'id' => $row->id]) : null;
+                        $data['delete_url'] = auth()->user()->can('access.data.lembaga.delete') ? route('data.lembaga_anggota.destroy', ['slug' => $slug, 'id' => $row->id]) : null;
                     }
 
                     return view('forms.aksi', $data);
@@ -56,31 +64,80 @@ class LembagaAnggotaController extends Controller
                 ->addColumn('no_anggota', function ($row) {
                     return $row->no_anggota ?: '-';
                 })
-                ->addColumn('nik', function ($row) {
+                ->addColumn('nik', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        return $penduduk ? ($penduduk['attributes']['nik'] ?? '-') : '-';
+                    }
+
                     return $row->penduduk->nik ?? '-';
                 })
-                ->addColumn('nama', function ($row) {
+                ->addColumn('nama', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        return $penduduk ? ($penduduk['attributes']['nama'] ?? '-') : '-';
+                    }
+
                     return $row->penduduk->nama ?? '-';
                 })
-                ->addColumn('tempat_tgl_lahir', function ($row) {
+                ->addColumn('tempat_tgl_lahir', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        $tempat = $penduduk ? ($penduduk['attributes']['tempatlahir'] ?? '-') : '-';
+                        $tanggalLahir = $penduduk && ($penduduk['attributes']['tanggallahir'] ?? false)
+                            ? Carbon::parse($penduduk['attributes']['tanggallahir'])->translatedFormat('d F Y')
+                            : '-';
+
+                        return "$tempat / $tanggalLahir";
+                    }
+
                     $tempat = $row->penduduk->tempat_lahir ?? '-';
                     $tanggalLahir = $row->penduduk->tanggal_lahir
                         ? Carbon::parse($row->penduduk->tanggal_lahir)->translatedFormat('d F Y')
                         : '-';
+
                     return "$tempat / $tanggalLahir";
                 })
-                ->addColumn('umur', function ($row) {
+                ->addColumn('umur', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        return $penduduk['attributes']['umur'] ?? '-';
+                    }
+
                     return $row->penduduk && $row->penduduk->tanggal_lahir
-                        ? \Carbon\Carbon::parse($row->penduduk->tanggal_lahir)->age
+                        ? Carbon::parse($row->penduduk->tanggal_lahir)->age
                         : '-';
                 })
-                ->addColumn('sex', function ($row) {
+                ->addColumn('sex', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+                        $sex = ['1' => 'Laki-laki', '2' => 'Perempuan'];
+                        return $penduduk ? ($sex[$penduduk['attributes']['sex']] ?? '-') : '-';
+                    }
+
                     return $row->penduduk && $row->penduduk->pendudukSex ? $row->penduduk->pendudukSex->nama : '-';
                 })
-                ->addColumn('alamat', function ($row) {
+                ->addColumn('alamat', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        if (!$penduduk) {
+                            return '-';
+                        }
+
+                        $alamat = $penduduk['attributes']['alamat_wilayah'] ?? '-';
+
+                        return $alamat;
+                    }
+
                     $rt = $row->penduduk->rt ?? '-';
                     $rw = $row->penduduk->rw ?? '-';
                     $alamat = $row->penduduk->dusun ?? '-';
+
                     return "RT $rt / RW $rw $alamat";
                 })
                 ->addColumn('jabatan', function ($row) {
@@ -136,15 +193,18 @@ class LembagaAnggotaController extends Controller
      */
     public function create($slug)
     {
-        // Cari lembaga berdasarkan slug
         $lembaga = Lembaga::where('slug', $slug)->firstOrFail();
 
-        // Ambil anggota yang sudah ada di lembaga ini
+        if ($this->isDatabaseGabungan()) {
+            $page_title = 'Tambah Anggota Lembaga ' . $lembaga->nama;
+            $page_description = 'Tambah Anggota Lembaga ' . $lembaga->nama;
+
+            return view('data.lembaga_anggota.gabungan.create', compact('page_title', 'page_description', 'lembaga'));
+        }
+
         $existingAnggotaIds = $lembaga->lembagaAnggota->pluck('penduduk_id')->toArray();
 
-        // Ambil semua penduduk yang belum menjadi anggota
         $pendudukList = Penduduk::whereNotIn('id', $existingAnggotaIds)->get()->mapWithKeys(function ($penduduk) {
-            // Membuat string yang menggabungkan NIK, nama, dan alamat
             $optionText = "NIK: {$penduduk->nik} - {$penduduk->nama} - Dusun {$penduduk->dusun} RT {$penduduk->rt} / RW {$penduduk->rw}";
 
             return [$penduduk->id => $optionText];
@@ -165,24 +225,25 @@ class LembagaAnggotaController extends Controller
      */
     public function store(StoreLembagaAnggotaRequest $request, $slug)
     {
-        // Cari lembaga berdasarkan slug
         $lembaga = Lembaga::where('slug', $slug)->firstOrFail();
 
-        // Cek apakah jabatan yang dipilih adalah Ketua (jabatan_id = 1)
         if ($request->jabatan_id == 1) {
-            // Cek apakah sudah ada Ketua di lembaga ini
             $existingKetua = $lembaga->lembagaAnggota()->where('jabatan', 1)->first();
 
-            // Jika ada, ubah jabatan ketua yang sudah ada menjadi Anggota (jabatan_id = 5)
             if ($existingKetua) {
                 $existingKetua->update(['jabatan' => 5]);
             }
         }
 
-        try {
+        $data = $request->validated();
 
-            $lembaga->lembagaAnggota()->create([
-                'penduduk_id' => $request->penduduk_id,
+        if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+            $data['penduduk_id'] = null;
+            $data['penduduk_id_gabungan'] = $data['penduduk_id_gabungan'] ?? null;
+        }
+
+        try {
+            $lembaga->lembagaAnggota()->create($data + [
                 'no_anggota' => $request->no_anggota,
                 'jabatan' => $request->jabatan_id,
                 'no_sk_jabatan' => $request->no_sk_jabatan,
@@ -193,7 +254,6 @@ class LembagaAnggotaController extends Controller
                 'periode' => $request->periode,
                 'keterangan' => $request->keterangan,
             ]);
-
         } catch (\Exception $e) {
             Log::error('Lembaga Anggota creation failed', [
                 'error' => $e->getMessage(),
@@ -216,13 +276,24 @@ class LembagaAnggotaController extends Controller
      */
     public function edit($slug, $id)
     {
-        // Cari lembaga berdasarkan slug
         $lembaga = Lembaga::where('slug', $slug)->firstOrFail();
-
-        // Cari anggota lembaga berdasarkan ID
         $anggota = LembagaAnggota::with('penduduk')->where('lembaga_id', $lembaga->id)->findOrFail($id);
 
-        // Ambil semua penduduk yang belum menjadi anggota kecuali yang sedang diedit
+        if ($this->isDatabaseGabungan()) {
+            $page_title = 'Ubah Anggota Lembaga ' . $lembaga->nama;
+            $page_description = 'Ubah Anggota Lembaga ' . $lembaga->nama;
+
+            $pendudukGabungan = (new PendudukService())->pendudukGabunganByIds([$anggota->penduduk_id_gabungan]);
+            $penduduk = new Penduduk();
+            if($pendudukGabungan[0]){                
+                $penduduk->nama = $pendudukGabungan[0]['attributes']['nama'];
+                $penduduk->nik = $pendudukGabungan[0]['attributes']['nik'];
+            }
+            $anggota->setRelation('penduduk', $penduduk);  
+
+            return view('data.lembaga_anggota.gabungan.edit', compact('page_title', 'page_description', 'lembaga', 'anggota'));
+        }
+
         $existingAnggotaIds = $lembaga->lembagaAnggota()
             ->where('id', '!=', $anggota->id)
             ->pluck('penduduk_id')
@@ -233,7 +304,6 @@ class LembagaAnggotaController extends Controller
             return [$penduduk->id => $optionText];
         });
 
-        // Tambahkan penduduk saat ini (yang sedang diedit) ke daftar pendudukList
         $pendudukList->prepend("NIK: {$anggota->penduduk->nik} - {$anggota->penduduk->nama} - Dusun {$anggota->penduduk->dusun} RT {$anggota->penduduk->rt} / RW {$anggota->penduduk->rw}", $anggota->penduduk->id);
 
         $page_title = 'Ubah Anggota Lembaga ' . $lembaga->nama;
@@ -252,28 +322,28 @@ class LembagaAnggotaController extends Controller
     public function update(UpdateLembagaAnggotaRequest $request, $slug, $id)
     {
         try {
-
-            // Cari lembaga berdasarkan slug
             $lembaga = Lembaga::where('slug', $slug)->firstOrFail();
 
-            // Cari anggota berdasarkan id dan pastikan anggota tersebut milik lembaga yang sesuai
             $anggota = LembagaAnggota::where('id', $id)
                 ->where('lembaga_id', $lembaga->id)
                 ->firstOrFail();
 
-            // Cek apakah jabatan yang dipilih adalah Ketua (jabatan_id = 1)
             if ($request->jabatan_id == 1) {
-                // Cek apakah sudah ada Ketua di lembaga ini
                 $existingKetua = $lembaga->lembagaAnggota()->where('jabatan', 1)->first();
 
-                // Jika ada Ketua lain, ubah jabatan Ketua yang sudah ada menjadi Anggota (jabatan_id = 5)
                 if ($existingKetua && $existingKetua->id !== $anggota->id) {
                     $existingKetua->update(['jabatan' => 5]);
                 }
             }
 
-            // Update data anggota
-            $anggota->update([
+            $data = $request->validated();
+
+            if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+                $data['penduduk_id'] = null;
+                $data['penduduk_id_gabungan'] = $data['penduduk_id_gabungan'] ?? null;
+            }
+
+            $anggota->update($data + [
                 'no_anggota' => $request->no_anggota,
                 'jabatan' => $request->jabatan_id,
                 'no_sk_jabatan' => $request->no_sk_jabatan,
@@ -284,7 +354,6 @@ class LembagaAnggotaController extends Controller
                 'periode' => $request->periode,
                 'keterangan' => $request->keterangan,
             ]);
-
         } catch (\Exception $e) {
             Log::error('Lembaga Anggota update failed', [
                 'error' => $e->getMessage(),

--- a/app/Http/Controllers/Data/LembagaController.php
+++ b/app/Http/Controllers/Data/LembagaController.php
@@ -2,17 +2,18 @@
 
 namespace App\Http\Controllers\Data;
 
-use App\Models\Lembaga;
-use App\Models\Penduduk;
-use Illuminate\Http\Request;
-use App\Models\LembagaAnggota;
-use App\Models\KategoriLembaga;
-use Yajra\DataTables\DataTables;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreLembagaRequest;
 use App\Http\Requests\UpdateLembagaRequest;
+use App\Models\KategoriLembaga;
+use App\Models\Lembaga;
+use App\Models\LembagaAnggota;
+use App\Models\Penduduk;
+use App\Services\PendudukService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Yajra\DataTables\DataTables;
 
 class LembagaController extends Controller
 {
@@ -35,14 +36,22 @@ class LembagaController extends Controller
     public function getData(Request $request)
     {
         if ($request->ajax()) {
-            $lembagaList = Lembaga::with(['lembagaKategori', 'penduduk', 'lembagaAnggota'])
+            $lembagaList = Lembaga::with(['lembagaKategori', 'penduduk', 'pendudukGabungan', 'lembagaAnggota'])
                 ->withCount('lembagaAnggota as jml_anggota')
                 ->get();
+
+            $pendudukGabunganIds = $lembagaList->pluck('penduduk_id_gabungan')->filter()->unique()->values()->all();
+
+            $pendudukGabungan = collect();
+            if ($this->isDatabaseGabungan() && !empty($pendudukGabunganIds)) {
+                $pendudukGabungan = (new PendudukService())->pendudukGabunganByIds($pendudukGabunganIds);
+            }
+
             return DataTables::of($lembagaList)
                 ->addIndexColumn()
                 ->addColumn('aksi', function ($row) {
                     if (!auth()->guest()) {
-                        $data['detail_url'] = auth()->user()->can('access.data.lembaga_anggota.view') ? route('data.lembaga_anggota.index', $row->slug) : null;
+                        $data['detail_url'] = auth()->user()->can('access.data.lembaga.view') ? route('data.lembaga_anggota.index', $row->slug) : null;
                         $data['edit_url'] = auth()->user()->can('access.data.lembaga.edit') ? route('data.lembaga.edit', $row->id) : null;
                         $data['delete_url'] = auth()->user()->can('access.data.lembaga.delete') ? route('data.lembaga.destroy', $row->id) : null;
                     }
@@ -52,7 +61,13 @@ class LembagaController extends Controller
                 ->addColumn('kategori', function ($row) {
                     return $row->lembagaKategori ? $row->lembagaKategori->nama : '-';
                 })
-                ->addColumn('ketua', function ($row) {
+                ->addColumn('ketua', function ($row) use ($pendudukGabungan) {
+                    if ($this->isDatabaseGabungan()) {
+                        $penduduk = $pendudukGabungan->firstWhere('id', $row->penduduk_id_gabungan);
+
+                        return $penduduk ? ($penduduk['attributes']['nama'] ?? '-') : '-';
+                    }
+
                     return $row->penduduk ? $row->penduduk->nama : '-';
                 })
                 ->rawColumns(['aksi'])
@@ -69,12 +84,15 @@ class LembagaController extends Controller
     {
         $page_title = $this->title;
         $page_description = 'Tambah ' . $this->title;
+
+        if ($this->isDatabaseGabungan()) {
+            $view = 'data.lembaga.gabungan.create';
+            return view($view, compact('page_title', 'page_description'));
+        }
+
         $kategoriLembagaList = KategoriLembaga::pluck('nama', 'id');
         $pendudukList = Penduduk::all()->mapWithKeys(function ($penduduk) {
-            // Membuat string yang menggabungkan NIK, nama, dan alamat
             $optionText = "NIK: {$penduduk->nik} - {$penduduk->nama} - Dusun {$penduduk->dusun} RT {$penduduk->rt} / RW {$penduduk->rw}";
-
-            // Menambahkan ke array dengan 'id' sebagai key dan $optionText sebagai value
             return [$penduduk->id => $optionText];
         });
 
@@ -85,24 +103,28 @@ class LembagaController extends Controller
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
+     *
      * @return \Illuminate\Http\Response
      */
     public function store(StoreLembagaRequest $request)
     {
         $data = $request->all();
 
-        // Menggunakan scope untuk menghasilkan slug yang unik
+        if ($this->isDatabaseGabungan()) {
+            $data['penduduk_id'] = null;
+            $data['penduduk_id_gabungan'] = $data['penduduk_id_gabungan'] ?? null;
+        }
+
         $data['slug'] = Lembaga::generateUniqueSlug($request->nama);
 
         try {
             DB::transaction(function () use ($data) {
-                // Insert ke table 'lembaga'
                 $lembaga = Lembaga::create($data);
 
-                // Insert ke tabel 'lembagaanggota' dengan id penduduk yang diambil dari input
                 LembagaAnggota::create([
                     'lembaga_id' => $lembaga->id,
                     'penduduk_id' => $data['penduduk_id'],
+                    'penduduk_id_gabungan' => $data['penduduk_id_gabungan'] ?? null,
                     'no_anggota' => 1,
                     'jabatan' => 1,
                     'keterangan' => 'Ketua lembaga'
@@ -125,6 +147,7 @@ class LembagaController extends Controller
      * Display the specified resource.
      *
      * @param  int  $id
+     *
      * @return \Illuminate\Http\Response
      */
     public function show($id)
@@ -136,6 +159,7 @@ class LembagaController extends Controller
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
+     *
      * @return \Illuminate\Http\Response
      */
     public function edit($id)
@@ -143,12 +167,22 @@ class LembagaController extends Controller
         $lembaga = Lembaga::findOrFail($id);
         $page_title = $this->title;
         $page_description = 'Ubah ' . $this->title;
+
+        if ($this->isDatabaseGabungan()) {
+            $view = 'data.lembaga.gabungan.edit';
+            $pendudukGabungan = (new PendudukService())->pendudukGabunganByIds([$lembaga->penduduk_id_gabungan]);
+            $penduduk = new Penduduk();
+            if($pendudukGabungan[0]){                
+                $penduduk->nama = $pendudukGabungan[0]['attributes']['nama'];
+                $penduduk->nik = $pendudukGabungan[0]['attributes']['nik'];
+            }
+            $lembaga->setRelation('penduduk', $penduduk);  
+            return view($view, compact('page_title', 'page_description', 'lembaga'));
+        }
+
         $kategoriLembagaList = KategoriLembaga::pluck('nama', 'id');
         $pendudukList = Penduduk::all()->mapWithKeys(function ($penduduk) {
-            // Membuat string yang menggabungkan NIK, nama, dan alamat
             $optionText = "NIK: {$penduduk->nik} - {$penduduk->nama} - Dusun {$penduduk->dusun} RT {$penduduk->rt} / RW {$penduduk->rw}";
-
-            // Menambahkan ke array dengan 'id' sebagai key dan $optionText sebagai value
             return [$penduduk->id => $optionText];
         });
 
@@ -160,6 +194,7 @@ class LembagaController extends Controller
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  int  $id
+     *
      * @return \Illuminate\Http\Response
      */
     public function update(UpdateLembagaRequest $request, $id)
@@ -168,24 +203,25 @@ class LembagaController extends Controller
 
         try {
             DB::transaction(function () use ($data, $request, $id) {
-                // Temukan lembaga yang akan diupdate
                 $lembaga = Lembaga::findOrFail($id);
 
-                // Hanya buat slug baru jika nama lembaga berubah
                 if ($request->nama !== $lembaga->nama) {
                     $data['slug'] = Lembaga::generateUniqueSlug($request->nama);
                 }
 
-                // Update data lembaga
+                if ($this->isDatabaseGabungan()) {
+                    $data['penduduk_id'] = null;
+                    $data['penduduk_id_gabungan'] = $data['penduduk_id_gabungan'] ?? null;
+                }
+
                 $lembaga->update($data);
 
-                // Cek apakah anggota terkait sudah ada
                 $anggota = LembagaAnggota::where('lembaga_id', $lembaga->id)->first();
 
                 if ($anggota) {
-                    // Update penduduk_id pada anggota jika anggota sudah ada
                     $anggota->update([
                         'penduduk_id' => $data['penduduk_id'] ?? $lembaga->penduduk_id,
+                        'penduduk_id_gabungan' => $data['penduduk_id_gabungan'] ?? $lembaga->penduduk_id_gabungan,
                     ]);
                 }
             });
@@ -202,11 +238,11 @@ class LembagaController extends Controller
         return redirect()->route('data.lembaga.index')->with('success', 'Lembaga berhasil diubah!');
     }
 
-
     /**
      * Remove the specified resource from storage.
      *
      * @param  int  $id
+     *
      * @return \Illuminate\Http\Response
      */
     public function destroy($id)

--- a/app/Http/Requests/StoreLembagaAnggotaRequest.php
+++ b/app/Http/Requests/StoreLembagaAnggotaRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\Lembaga;
+use App\Models\SettingAplikasi;
 use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -25,9 +26,22 @@ class StoreLembagaAnggotaRequest extends FormRequest
      */
     public function rules()
     {
-        $slug = $this->route('slug'); 
+        $slug = $this->route('slug');
         $lembaga = Lembaga::where('slug', $slug)->first();
-        
+
+        if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+            return [
+                'penduduk_id' => 'nullable|integer',
+                'penduduk_id_gabungan' => 'required|integer',
+                'no_anggota' => [
+                    'required',
+                    Rule::unique('das_lembaga_anggota', 'no_anggota')
+                        ->where('lembaga_id', $lembaga->id),
+                ],
+                'jabatan_id' => 'required|in:1,2,3,4,5',
+            ];
+        }
+
         return [
             'penduduk_id' => 'required|exists:das_penduduk,id',
             'no_anggota' => [
@@ -35,7 +49,7 @@ class StoreLembagaAnggotaRequest extends FormRequest
                 Rule::unique('das_lembaga_anggota', 'no_anggota')
                     ->where('lembaga_id', $lembaga->id),
             ],
-            'jabatan_id' => 'required|in:1,2,3,4,5', // Kode jabatan harus 1-5
+            'jabatan_id' => 'required|in:1,2,3,4,5',
         ];
     }
 
@@ -48,6 +62,7 @@ class StoreLembagaAnggotaRequest extends FormRequest
     {
         return [
             'penduduk_id' => 'Nama Anggota',
+            'penduduk_id_gabungan' => 'Nama Anggota',
             'no_anggota' => 'Nomor Anggota',
             'jabatan_id' => 'Jabatan',
         ];

--- a/app/Http/Requests/StoreLembagaRequest.php
+++ b/app/Http/Requests/StoreLembagaRequest.php
@@ -2,33 +2,31 @@
 
 namespace App\Http\Requests;
 
+use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreLembagaRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
-     */
     public function authorize()
     {
         return true;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, mixed>
-     */
     public function rules()
     {
-        return [
+        $rules = [
             'nama' => 'required|string|max:255',
             'kode' => 'required|string|max:255|unique:das_lembaga,kode',
             'lembaga_kategori_id' => 'required|exists:das_lembaga_kategori,id',
-            'penduduk_id' => 'required|exists:das_penduduk,id',
         ];
+
+        if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+            $rules['penduduk_id_gabungan'] = 'required|integer';
+        } else {
+            $rules['penduduk_id'] = 'required|exists:das_penduduk,id';
+        }
+
+        return $rules;
     }
 
     /**
@@ -43,6 +41,7 @@ class StoreLembagaRequest extends FormRequest
             'kode' => 'Kode Lembaga',
             'lembaga_kategori_id' => 'Kategori Lembaga',
             'penduduk_id' => 'Ketua Lembaga',
+            'penduduk_id_gabungan' => 'Ketua Lembaga',
         ];
     }
 }

--- a/app/Http/Requests/UpdateLembagaAnggotaRequest.php
+++ b/app/Http/Requests/UpdateLembagaAnggotaRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\LembagaAnggota;
+use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateLembagaAnggotaRequest extends FormRequest
@@ -25,22 +26,23 @@ class UpdateLembagaAnggotaRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            // 'no_anggota' => 'required|unique:das_lembaga_anggota,no_anggota', // pastikan id penduduk ada dalam tabel
-            'jabatan_id' => 'required|in:1,2,3,4,5', // kode jabatan harus 1-5
+            'jabatan_id' => 'required|in:1,2,3,4,5',
         ];
 
         $id = $this->route('id');
 
-        // cek no_anggota berdasarkan id
         $anggota = LembagaAnggota::findOrFail($id);
-        
-        // jika inputan nomor anggota tidak sama dengan data no_anggota
-        if($this->input('no_anggota') !== $anggota->no_anggota){
+
+        if ($this->input('no_anggota') !== $anggota->no_anggota) {
             $rules['no_anggota'] = 'required|unique:das_lembaga_anggota,no_anggota';
         }
 
-        return $rules;
+        if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+            $rules['penduduk_id'] = 'nullable|integer';
+            $rules['penduduk_id_gabungan'] = 'required|integer';
+        }
 
+        return $rules;
     }
 
     /**
@@ -51,6 +53,8 @@ class UpdateLembagaAnggotaRequest extends FormRequest
     public function attributes()
     {
         return [
+            'penduduk_id' => 'Nama Anggota',
+            'penduduk_id_gabungan' => 'Nama Anggota',
             'no_anggota' => 'Nomor Anggota',
             'jabatan_id' => 'Jabatan',
         ];

--- a/app/Http/Requests/UpdateLembagaRequest.php
+++ b/app/Http/Requests/UpdateLembagaRequest.php
@@ -3,41 +3,35 @@
 namespace App\Http\Requests;
 
 use App\Models\Lembaga;
+use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateLembagaRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
-     */
     public function authorize()
     {
         return true;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, mixed>
-     */
     public function rules()
     {
         $rules = [
             'nama' => 'required|string|max:255',
             'lembaga_kategori_id' => 'required|exists:das_lembaga_kategori,id',
-            'penduduk_id' => 'required|exists:das_penduduk,id',
         ];
 
-        // Dapatkan id lembaga dari route
         $id = $this->route('id');
-
-        // Cek apakah field kode mengalami perubahan
         $lembaga = Lembaga::findOrFail($id);
-        
+
         if ($this->input('kode') !== $lembaga->kode) {
             $rules['kode'] = 'required|string|max:255|unique:das_lembaga,kode';
+        }
+
+        if (SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1') {
+            $rules['penduduk_id'] = 'nullable|integer';
+            $rules['penduduk_id_gabungan'] = 'required|integer';
+        } else {
+            $rules['penduduk_id'] = 'required|exists:das_penduduk,id';
         }
 
         return $rules;
@@ -55,6 +49,7 @@ class UpdateLembagaRequest extends FormRequest
             'kode' => 'Kode Lembaga',
             'lembaga_kategori_id' => 'Kategori Lembaga',
             'penduduk_id' => 'Ketua Lembaga',
+            'penduduk_id_gabungan' => 'Ketua Lembaga',
         ];
     }
 }

--- a/app/Models/Lembaga.php
+++ b/app/Models/Lembaga.php
@@ -31,6 +31,11 @@ class Lembaga extends Model
         return $this->belongsTo(Penduduk::class, 'penduduk_id', 'id');
     }
 
+    public function pendudukGabungan()
+    {
+        return $this->belongsTo(Penduduk::class, 'penduduk_id_gabungan', 'id');
+    }
+
     // Scope untuk membuat slug yang unik
     public static function generateUniqueSlug($nama)
     {

--- a/app/Models/LembagaAnggota.php
+++ b/app/Models/LembagaAnggota.php
@@ -18,10 +18,14 @@ class LembagaAnggota extends Model
         return $this->belongsTo(Lembaga::class, 'lembaga_id');
     }
 
-    // Relasi ke model Penduduk (Many-to-One)
     public function penduduk()
     {
         return $this->belongsTo(Penduduk::class, 'penduduk_id');
+    }
+
+    public function pendudukGabungan()
+    {
+        return $this->belongsTo(Penduduk::class, 'penduduk_id_gabungan');
     }
 
     // Menentukan kolom slug yang digunakan untuk pencarian di rute

--- a/app/Services/PendudukService.php
+++ b/app/Services/PendudukService.php
@@ -3,14 +3,13 @@
 namespace App\Services;
 
 use App\Models\Penduduk;
-use App\Models\SettingAplikasi;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class PendudukService extends BaseApiService
 {
     /**
-     * Get Unique Desa
+     * Get Unique Desa.
      */
     public function jumlahPenduduk(array $filters = [])
     {
@@ -33,7 +32,7 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Get Unique Desa
+     * Get Unique Desa.
      */
     public function desa(array $filters = [])
     {
@@ -59,7 +58,7 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Export Data Penduduk
+     * Export Data Penduduk.
      */
     public function exportPenduduk($size, $number, $search)
     {
@@ -110,7 +109,30 @@ class PendudukService extends BaseApiService
     }
 
     /**
-     * Export Data Penduduk
+     * Ambil beberapa data penduduk dari database gabungan sekaligus
+     * menggunakan filter id_penduduk berupa array.
+     *
+     * @param  array<int, int|string>  $ids
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function pendudukGabunganByIds(array $ids)
+    {
+        if (empty($ids)) {
+            return collect();
+        }
+
+        $data = $this->apiRequest('/api/v1/opendk/sync-penduduk-opendk', [
+            'filter[kode_kecamatan]' => str_replace('.', '', config('profil.kecamatan_id')),
+            'filter[id_penduduk]' => $ids,
+            'page[size]' => count($ids),
+        ]);
+
+        return collect($data)->filter(fn (mixed $item): bool => is_array($item));
+    }
+
+    /**
+     * Export Data Penduduk.
      */
     public function cekPendudukNikTanggalLahir($nik, $tgl_lhr = null)
     {

--- a/database/migrations/2026_09_08_055444_add_penduduk_id_gabungan_to_lembaga_tables.php
+++ b/database/migrations/2026_09_08_055444_add_penduduk_id_gabungan_to_lembaga_tables.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('das_lembaga', function (Blueprint $table) {
+            $table->unsignedInteger('penduduk_id_gabungan')->nullable()->after('penduduk_id');
+        });
+
+        Schema::table('das_lembaga_anggota', function (Blueprint $table) {
+            $table->unsignedInteger('penduduk_id_gabungan')->nullable()->after('penduduk_id');
+            $table->dropForeign(['penduduk_id']);
+            $table->unsignedInteger('penduduk_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('das_lembaga', function (Blueprint $table) {
+            $table->dropColumn('penduduk_id_gabungan');
+        });
+
+        Schema::table('das_lembaga_anggota', function (Blueprint $table) {
+            $table->unsignedInteger('penduduk_id')->nullable(false)->change();
+            $table->foreign('penduduk_id')->references('id')->on('das_penduduk')->onDelete('cascade');
+            $table->dropColumn('penduduk_id_gabungan');
+        });
+    }
+};

--- a/resources/views/components/penduduk-gabungan-select.blade.php
+++ b/resources/views/components/penduduk-gabungan-select.blade.php
@@ -1,0 +1,81 @@
+@props([
+    'name' => 'penduduk_id',
+    'id' => 'penduduk_id_gabungan',
+    'selected' => null,
+    'selectedText' => null,
+    'placeholder' => 'Pilih Ketua Lembaga',
+    'required' => false,
+    'apiServerDatabase' => null,
+    'apiKeyDatabase' => null,
+    'kodeKecamatan' => null,
+])
+
+@php
+    $apiServerDatabase = $apiServerDatabase ?? ($settings['api_server_database_gabungan'] ?? '');
+    $apiKeyDatabase = $apiKeyDatabase ?? ($settings['api_key_database_gabungan'] ?? '');
+    $kodeKecamatan = $kodeKecamatan ?? (isset($profil) ? str_replace('.', '', $profil->kecamatan_id) : '');
+@endphp
+
+<div style="display: flex; flex-direction: column;">
+    <select
+        name="{{ $name }}"
+        id="{{ $id }}"
+        class="form-control select2"
+        {{ $required ? 'required' : '' }}>
+        <option value="">{{ $placeholder }}</option>
+        @if($selected)
+            <option value="{{ $selected }}" selected>{{ $selectedText }}</option>
+        @endif
+    </select>
+</div>
+
+@push('scripts')
+    <script>
+        $(function() {
+            var $penduduk = $('#{{ $id }}');
+
+            $penduduk.select2({
+                placeholder: '{{ $placeholder }}',
+                width: '100%',
+                minimumInputLength: 0,
+                allowClear: true,
+                ajax: {
+                    url: `{{ $apiServerDatabase }}/api/v1/opendk/sync-penduduk-opendk`,
+                    dataType: 'json',
+                    delay: 400,
+                    headers: {
+                        "Authorization": `Bearer {{ $apiKeyDatabase }}`,
+                        "Accept": "application/ld+json"
+                    },
+                    data: function(params) {
+                        return {
+                            'filter[kode_kecamatan]': '{{ $kodeKecamatan }}',
+                            'filter[status_dasar]': 1,
+                            'filter[search]': params.term,
+                            'page[size]': 20,
+                            'page[number]': params.page || 1,
+                        };
+                    },
+                    processResults: function(response, params) {
+                        params.page = params.page || 1;
+                        var total = (response.meta && response.meta.pagination && response.meta.pagination.total) || 0;
+
+                        return {
+                            results: $.map(response.data || [], function(item) {
+                                var attributes = item.attributes || {};
+                                return {
+                                    id: item.id,
+                                    text: attributes.nama + ' - ' + (attributes.nik || ''),
+                                };
+                            }),
+                            pagination: {
+                                more: params.page * 20 < total
+                            }
+                        };
+                    },
+                    cache: true
+                }
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/data/lembaga/gabungan/create.blade.php
+++ b/resources/views/data/lembaga/gabungan/create.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    {!! html()->form('POST', route('data.lembaga.store'))->id('form-lembaga')->class('form-horizontal form-label-left')->open() !!}
+                    @include('layouts.fragments.error_message')
+                    <div class="box-body">                        
+
+                        @include('flash::message')
+                        @include('data.lembaga.gabungan.form_create')
+
+                    </div>
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.tinymce_min')

--- a/resources/views/data/lembaga/gabungan/edit.blade.php
+++ b/resources/views/data/lembaga/gabungan/edit.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    {!! html()->form('PUT', route('data.lembaga.update', $lembaga->id))->id('form-lembaga')->class('form-horizontal form-label-left')->open() !!}
+                    @include('layouts.fragments.error_message')
+                    <div class="box-body">                        
+
+                        @include('flash::message')
+                        @include('data.lembaga.gabungan.form_edit')
+
+                    </div>
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.tinymce_min')

--- a/resources/views/data/lembaga/gabungan/form_create.blade.php
+++ b/resources/views/data/lembaga/gabungan/form_create.blade.php
@@ -1,0 +1,53 @@
+@include('partials.asset_select2')
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('nama')->value(old('nama', isset($lembaga) ? $lembaga->nama : ''))->class('form-control')->required()->placeholder('Nama Lembaga') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Kode Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('kode')->value(old('kode', isset($lembaga) ? $lembaga->kode : ''))->class('form-control')->required()->placeholder('Kode Lembaga') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Kategori Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <select name="lembaga_kategori_id" class="form-control select2" data-width="100%" required>
+            <option value="">Pilih Kategori Lembaga</option>
+            @foreach(\App\Models\KategoriLembaga::orderBy('nama')->get() as $kategori)
+            <option value="{{ $kategori->id }}" {{ old('lembaga_kategori_id', isset($lembaga) ? $lembaga->lembaga_kategori_id : '') == $kategori->id ? 'selected' : '' }}>
+                {{ $kategori->nama }}
+            </option>
+            @endforeach
+        </select>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Ketua Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <x-penduduk-gabungan-select
+            name="penduduk_id_gabungan"
+            required />
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Deskripsi Lembaga</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->textarea('keterangan')->value(old('keterangan', isset($lembaga) ? $lembaga->keterangan : ''))->class('form-control')->placeholder('Deskripsi Lembaga')->rows(2) !!}
+    </div>
+</div>
+
+<div class="ln_solid"></div>
+
+@include('partials.asset_jqueryvalidation')

--- a/resources/views/data/lembaga/gabungan/form_edit.blade.php
+++ b/resources/views/data/lembaga/gabungan/form_edit.blade.php
@@ -1,0 +1,59 @@
+@include('partials.asset_select2')
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('nama')->value(old('nama', isset($lembaga) ? $lembaga->nama : ''))->class('form-control')->required()->placeholder('Nama Lembaga') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Kode Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('kode')->value(old('kode', isset($lembaga) ? $lembaga->kode : ''))->class('form-control')->required()->placeholder('Kode Lembaga') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Kategori Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <select name="lembaga_kategori_id" class="form-control select2" required  data-width="100%">
+            <option value="">Pilih Kategori Lembaga</option>
+            @foreach(\App\Models\KategoriLembaga::orderBy('nama')->get() as $kategori)
+            <option value="{{ $kategori->id }}" {{ old('lembaga_kategori_id', isset($lembaga) ? $lembaga->lembaga_kategori_id : '') == $kategori->id ? 'selected' : '' }}>
+                {{ $kategori->nama }}
+            </option>
+            @endforeach
+        </select>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Ketua Lembaga <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <x-penduduk-gabungan-select
+            name="penduduk_id_gabungan"
+            required
+            :selected="old('penduduk_id_gabungan', isset($lembaga) ? $lembaga->penduduk_id_gabungan : null)"
+            :selectedText="isset($lembaga) && $lembaga->penduduk_id_gabungan ? $lembaga->penduduk->nama . ' - ' . $lembaga->penduduk->nik : null" />
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Deskripsi Lembaga</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->textarea('keterangan')->value(old('keterangan', isset($lembaga) ? $lembaga->keterangan : ''))->class('form-control')->placeholder('Deskripsi Lembaga')->rows(2) !!}
+    </div>
+</div>
+
+<div class="ln_solid"></div>
+
+@include('partials.asset_jqueryvalidation')
+
+@push('scripts')
+{!! JsValidator::formRequest('App\Http\Requests\UpdateLembagaRequest', '#form-lembaga') !!}
+@endpush

--- a/resources/views/data/lembaga_anggota/gabungan/create.blade.php
+++ b/resources/views/data/lembaga_anggota/gabungan/create.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="{{ route('data.lembaga.index') }}"> Daftar Lembaga</a></li>
+            <li><a href="{{ route('data.lembaga_anggota.index', $lembaga->slug) }}"> Daftar Anggota Lembaga
+                    {{ $lembaga->nama }} </a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    {!! html()->form()->route('data.lembaga_anggota.store', $lembaga->slug)->method('POST')->id('form-lembaga-anggota')->class('form-horizontal form-label-left')->open() !!}
+                    @include('layouts.fragments.error_message')
+
+                    <div class="box-body">
+
+                        @include('flash::message')
+                        @include('data.lembaga_anggota.gabungan.form_create')
+
+                    </div>
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.tinymce_min')

--- a/resources/views/data/lembaga_anggota/gabungan/edit.blade.php
+++ b/resources/views/data/lembaga_anggota/gabungan/edit.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.dashboard_template')
+
+@section('content')
+    <section class="content-header block-breadcrumb">
+        <h1>
+            {{ $page_title ?? 'Page Title' }}
+            <small>{{ $page_description ?? '' }}</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li><a href="{{ route('dashboard') }}"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="{{ route('data.lembaga.index') }}"> Daftar Lembaga</a></li>
+            <li><a href="{{ route('data.lembaga_anggota.index', $lembaga->slug) }}"> Daftar Anggota Lembaga
+                    {{ $lembaga->nama }} </a></li>
+            <li class="active">{{ $page_description }}</li>
+        </ol>
+    </section>
+    <section class="content container-fluid">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box box-primary">
+
+                    {!! html()->form(
+                            'PUT',
+                            route('data.lembaga_anggota.update', [
+                                'id' => $anggota->id,
+                                'slug' => $lembaga->slug,
+                            ]),
+                        )->id('form-lembaga-anggota')->class('form-horizontal form-label-left')->open() !!}
+
+                    @include('layouts.fragments.error_message')
+
+                    <div class="box-body">
+
+                        @include('flash::message')
+                        @include('data.lembaga_anggota.gabungan.form_edit')
+
+                    </div>
+                    <div class="box-footer">
+                        @include('partials.button_reset_submit')
+                    </div>
+                    {!! html()->form()->close() !!}
+                </div>
+            </div>
+        </div>
+    </section>
+@endsection
+
+@include('partials.tinymce_min')

--- a/resources/views/data/lembaga_anggota/gabungan/form_create.blade.php
+++ b/resources/views/data/lembaga_anggota/gabungan/form_create.blade.php
@@ -1,0 +1,99 @@
+@include('partials.asset_select2')
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama Anggota <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <x-penduduk-gabungan-select
+            name="penduduk_id_gabungan"
+            placeholder="Pilih Anggota"
+            required />
+    </div>
+</div>
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor Anggota <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->number('no_anggota')->value(old('no_anggota', isset($anggota) ? $anggota->no_anggota : ''))->class('form-control')->required()->placeholder('Nomor Anggota')->attribute('min', 1) !!}
+        <small class="text-danger" style="font-style: italic; font-weight: 700">*Pastikan nomor anggota belum pernah digunakan !</small>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Jabatan <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <div style="display: flex; flex-direction: column;">
+            {!! html()->select('jabatan_id', [
+                    1 => 'Ketua',
+                    2 => 'Wakil Ketua',
+                    3 => 'Sekretaris',
+                    4 => 'Bendahara',
+                    5 => 'Anggota',
+                ])->value(old('jabatan_id', isset($anggota) ? $anggota->jabatan : ''))->placeholder('Pilih Jabatan')->class('form-control select2')->required()->style('width:100%;') !!}
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Jabatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_jabatan')->value(old('no_sk_jabatan', isset($anggota) ? $anggota->no_sk_jabatan : ''))->class('form-control')->placeholder('Nomor SK Jabatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Pengangkatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_pengangkatan')->value(old('no_sk_pengangkatan', isset($anggota) ? $anggota->no_sk_pengangkatan : ''))->class('form-control')->placeholder('Nomor SK Pengangkatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Tanggal SK Pengangkatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->date('tgl_sk_pengangkatan')->value(old('tgl_sk_pengangkatan', isset($anggota) ? $anggota->tgl_sk_pengangkatan : ''))->class('form-control')->placeholder('Tanggal SK Pengangkatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Pemberhentian</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_pemberhentian')->value(old('no_sk_pemberhentian', isset($anggota) ? $anggota->no_sk_pemberhentian : ''))->class('form-control')->placeholder('Nomor SK Pemberhentian') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Tanggal SK Pemberhentian</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->date('tgl_sk_pemberhentian')->value(old('tgl_sk_pemberhentian', isset($anggota) ? $anggota->tgl_sk_pemberhentian : ''))->class('form-control')->placeholder('Tanggal SK Pemberhentian') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Masa Jabatan (Usia/Periode)</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('periode')->value(old('periode', isset($anggota) ? $anggota->periode : ''))->class('form-control')->placeholder('Contoh: 6 Tahun Periode Pertama (2015 s/d 2021)') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Keterangan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->textarea('keterangan')->value(old('keterangan', isset($anggota) ? $anggota->keterangan : ''))->class('form-control')->placeholder('Keterangan')->rows(2) !!}
+    </div>
+</div>
+
+<div class="ln_solid"></div>
+
+@include('partials.asset_jqueryvalidation')
+
+@push('scripts')
+    {!! JsValidator::formRequest('App\Http\Requests\StoreLembagaAnggotaRequest', '#form-lembaga-anggota') !!}
+@endpush

--- a/resources/views/data/lembaga_anggota/gabungan/form_edit.blade.php
+++ b/resources/views/data/lembaga_anggota/gabungan/form_edit.blade.php
@@ -1,0 +1,101 @@
+@include('partials.asset_select2')
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nama Anggota <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <x-penduduk-gabungan-select
+            name="penduduk_id_gabungan"
+            placeholder="Pilih Anggota"
+            required
+            :selected="old('penduduk_id_gabungan', isset($anggota) ? $lembaga->penduduk_id_gabungan : null)"
+            :selectedText="isset($anggota) && $anggota->penduduk_id_gabungan ? $anggota->penduduk->nama . ' - ' . $anggota->penduduk->nik : null" />
+    </div>
+</div>
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor Anggota <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->number('no_anggota')->value(old('no_anggota', $anggota->no_anggota ?? ''))->class('form-control')->required()->placeholder('Nomor Anggota')->attribute('min', 1) !!}
+        <small class="text-danger" style="font-style: italic; font-weight: 700">*Pastikan nomor anggota belum pernah digunakan !</small>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Jabatan <span class="required">*</span></label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        <div style="display: flex; flex-direction: column;">
+            {!! html()->select('jabatan_id', [
+                    1 => 'Ketua',
+                    2 => 'Wakil Ketua',
+                    3 => 'Sekretaris',
+                    4 => 'Bendahara',
+                    5 => 'Anggota',
+                ])->value(old('jabatan_id', isset($anggota) ? $anggota->jabatan : ''))->placeholder('Pilih Jabatan')->class('form-control select2')->required()->style('width:100%;') !!}
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Jabatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_jabatan')->value(old('no_sk_jabatan', $anggota->no_sk_jabatan ?? ''))->class('form-control')->placeholder('Nomor SK Jabatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Pengangkatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_pengangkatan')->value(old('no_sk_pengangkatan', $anggota->no_sk_pengangkatan ?? ''))->class('form-control')->placeholder('Nomor SK Pengangkatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Tanggal SK Pengangkatan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->date('tgl_sk_pengangkatan')->value(old('tgl_sk_pengangkatan', $anggota->tgl_sk_pengangkatan ?? ''))->class('form-control')->placeholder('Tanggal SK Pengangkatan') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Nomor SK Pemberhentian</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('no_sk_pemberhentian')->value(old('no_sk_pemberhentian', $anggota->no_sk_pemberhentian ?? ''))->class('form-control')->placeholder('Nomor SK Pemberhentian') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Tanggal SK Pemberhentian</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->date('tgl_sk_pemberhentian')->value(old('tgl_sk_pemberhentian', $anggota->tgl_sk_pemberhentian ?? ''))->class('form-control')->placeholder('Tanggal SK Pemberhentian') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Masa Jabatan (Usia/Periode)</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->text('periode')->value(old('periode', $anggota->periode ?? ''))->class('form-control')->placeholder('Contoh: 6 Tahun Periode Pertama (2015 s/d 2021)') !!}
+    </div>
+</div>
+
+<div class="form-group">
+    <label class="control-label col-md-3 col-sm-3 col-xs-12">Keterangan</label>
+
+    <div class="col-md-6 col-sm-6 col-xs-12">
+        {!! html()->textarea('keterangan')->value(old('keterangan', $anggota->keterangan ?? ''))->class('form-control')->placeholder('Keterangan')->rows(2) !!}
+    </div>
+</div>
+
+<div class="ln_solid"></div>
+
+@include('partials.asset_jqueryvalidation')
+
+@push('scripts')
+    {!! JsValidator::formRequest('App\Http\Requests\UpdateLembagaAnggotaRequest', '#form-lembaga-anggota') !!}
+@endpush

--- a/resources/views/data/lembaga_anggota/index.blade.php
+++ b/resources/views/data/lembaga_anggota/index.blade.php
@@ -26,7 +26,7 @@
         <div class="box box-primary">
             <div class="box-header with-border">
                 @include('forms.btn-social', [
-                    'create_url' => auth()->user()->can('access.data.lembaga_anggota.create') ? route('data.lembaga_anggota.create', $lembaga->slug) : null,
+                    'create_url' => auth()->user()->can('access.data.lembaga.create') ? route('data.lembaga_anggota.create', $lembaga->slug) : null,
                 ])
             </div>
             <div class="box-body">
@@ -47,7 +47,7 @@
                         <tr>
                             <td>Ketua Lembaga</td>
                             <td>:</td>
-                            <td>{{ $lembaga->penduduk->nama }}</td>
+                            <td>{{ $lembaga->penduduk?->nama ?? $lembaga->pendudukGabungan?->nama ?? '-' }}</td>
                         </tr>
                         <tr>
                             <td>Kategori Lembaga</td>
@@ -102,7 +102,6 @@
                 processing: true,
                 serverSide: false,
                 ordering: false,
-                scrollX: true,
                 ajax: "{!! route('data.lembaga_anggota.getdata', $lembaga->slug) !!}",
                 columns: [{
                         data: 'aksi',

--- a/tests/Feature/LembagaAnggotaControllerTest.php
+++ b/tests/Feature/LembagaAnggotaControllerTest.php
@@ -60,7 +60,7 @@ beforeEach(function () {
     );
 });
 
-function getLembagaPenduduk()
+function getLembagaPendudukAnggota()
 {
     $penduduk = Penduduk::inRandomOrder()->first();
     if (!$penduduk) {
@@ -70,7 +70,7 @@ function getLembagaPenduduk()
     return $penduduk;
 }
 
-function getLembagaKategori()
+function getLembagaKategoriAnggota()
 {
     $kategori = KategoriLembaga::inRandomOrder()->first();
     if (!$kategori) {
@@ -81,8 +81,8 @@ function getLembagaKategori()
 }
 
 test('it can create lembaga anggota', function () {
-    $penduduk = getLembagaPenduduk();
-    $kategori = getLembagaKategori();
+    $penduduk = getLembagaPendudukAnggota();
+    $kategori = getLembagaKategoriAnggota();
     $lembaga = Lembaga::factory()->create([
         'lembaga_kategori_id' => $kategori->id,
         'penduduk_id' => $penduduk->id,
@@ -110,8 +110,8 @@ test('it can create lembaga anggota', function () {
 });
 
 test('it can update lembaga anggota', function () {
-    $penduduk = getLembagaPenduduk();
-    $kategori = getLembagaKategori();
+    $penduduk = getLembagaPendudukAnggota();
+    $kategori = getLembagaKategoriAnggota();
     $lembaga = Lembaga::factory()->create([
         'lembaga_kategori_id' => $kategori->id,
         'penduduk_id' => $penduduk->id,
@@ -136,8 +136,8 @@ test('it can update lembaga anggota', function () {
 });
 
 test('it can delete lembaga anggota', function () {
-    $penduduk = getLembagaPenduduk();
-    $kategori = getLembagaKategori();
+    $penduduk = getLembagaPendudukAnggota();
+    $kategori = getLembagaKategoriAnggota();
     $lembaga = Lembaga::factory()->create([
         'lembaga_kategori_id' => $kategori->id,
         'penduduk_id' => $penduduk->id,

--- a/tests/Feature/LembagaControllerTest.php
+++ b/tests/Feature/LembagaControllerTest.php
@@ -103,6 +103,23 @@ test('it can show create lembaga page (gabungan mode)', function () {
         ['value' => 'test-key']
     );
 
+    Http::fake([
+        'http://localhost:8000/api/v1/wilayah/desa*' => Http::response([
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'kode_desa' => '5102060001',
+                        'nama_desa' => 'Desa Test',
+                        'sebutan_desa' => 'Desa',
+                        'path' => null,
+                    ],
+                ],
+            ],
+        ], 200),
+        'http://localhost:8000/*' => Http::response(['data' => []], 200),
+    ]);
+
     $response = get(route('data.lembaga.create'));
 
     $response->assertStatus(200);
@@ -125,7 +142,20 @@ test('it can show edit lembaga page (gabungan mode)', function () {
     );
 
     Http::fake([
-        'http://localhost:8000/*' => Http::response([
+        'http://localhost:8000/api/v1/wilayah/desa*' => Http::response([
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'kode_desa' => '5102060001',
+                        'nama_desa' => 'Desa Test',
+                        'sebutan_desa' => 'Desa',
+                        'path' => null,
+                    ],
+                ],
+            ],
+        ], 200),
+        'http://localhost:8000/api/v1/opendk/sync-penduduk-opendk*' => Http::response([
             'data' => [
                 [
                     'id' => 1,
@@ -136,6 +166,7 @@ test('it can show edit lembaga page (gabungan mode)', function () {
                 ],
             ],
         ], 200),
+        'http://localhost:8000/*' => Http::response(['data' => []], 200),
     ]);
 
     $penduduk = getLembagaPenduduk();

--- a/tests/Feature/LembagaControllerTest.php
+++ b/tests/Feature/LembagaControllerTest.php
@@ -34,6 +34,7 @@ use App\Models\Lembaga;
 use App\Models\Penduduk;
 use App\Models\SettingAplikasi;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Http;
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
@@ -122,6 +123,20 @@ test('it can show edit lembaga page (gabungan mode)', function () {
         ['key' => 'api_key_database_gabungan'],
         ['value' => 'test-key']
     );
+
+    Http::fake([
+        'http://localhost:8000/*' => Http::response([
+            'data' => [
+                [
+                    'id' => 1,
+                    'attributes' => [
+                        'nama' => 'John Doe',
+                        'nik' => '1234567890123456',
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
 
     $penduduk = getLembagaPenduduk();
     $kategori = getLembagaKategori();

--- a/tests/Feature/LembagaControllerTest.php
+++ b/tests/Feature/LembagaControllerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * File ini bagian dari:
+ *
+ * OpenDK
+ *
+ * Aplikasi dan source code ini dirilis berdasarkan lisensi GPL V3
+ *
+ * Hak Cipta 2017 - 2025 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ *
+ * Dengan ini diberikan izin, secara gratis, kepada siapa pun yang mendapatkan salinan
+ * dari perangkat lunak ini dan file dokumentasi terkait ("Aplikasi Ini"), untuk diperlakukan
+ * tanpa batasan, termasuk hak untuk menggunakan, menyalin, mengubah dan/atau mendistribusikan,
+ * asal tunduk pada syarat berikut:
+ *
+ * Pemberitahuan hak cipta di atas dan pemberitahuan izin ini harus disertakan dalam
+ * setiap salinan atau bagian penting Aplikasi Ini. Barang siapa yang menghapus atau menghilangkan
+ * pemberitahuan ini melanggar ketentuan lisensi Aplikasi Ini.
+ *
+ * PERANGKAT LUNAK INI DISEDIAKAN "SEBAGAIMANA ADANYA", TANPA JAMINAN APA PUN, BAIK TERSURAT MAUPUN
+ * TERSIRAT. PENULIS ATAU PEMEGANG HAK CIPTA SAMA SEKALI TIDAK BERTANGGUNG JAWAB ATAS KLAIM, KERUSAKAN ATAU
+ * KEWAJIBAN APAPUN ATAS PENGGUNAAN ATAU LAINNYA TERKAIT APLIKASI INI.
+ *
+ * @package    OpenDK
+ * @author     Tim Pengembang OpenDesa
+ * @copyright  Hak Cipta 2017 - 2025 Perkumpulan Desa Digital Terbuka (https://opendesa.id)
+ * @license    http://www.gnu.org/licenses/gpl.html    GPL V3
+ * @link       https://github.com/OpenSID/opendk
+ */
+
+use App\Models\KategoriLembaga;
+use App\Models\Lembaga;
+use App\Models\Penduduk;
+use App\Models\SettingAplikasi;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->withViewErrors([]);
+    $this->withoutMiddleware([
+        \App\Http\Middleware\Authenticate::class,
+        \Spatie\Permission\Middleware\PermissionMiddleware::class,
+        \Spatie\Permission\Middleware\RoleMiddleware::class,
+        \App\Http\Middleware\CompleteProfile::class,
+        \App\Http\Middleware\GlobalShareMiddleware::class,
+    ]);
+});
+
+function getLembagaPenduduk()
+{
+    $penduduk = Penduduk::inRandomOrder()->first();
+    if (!$penduduk) {
+        Penduduk::factory()->create();
+        $penduduk = Penduduk::inRandomOrder()->first();
+    }
+    return $penduduk;
+}
+
+function getLembagaKategori()
+{
+    $kategori = KategoriLembaga::inRandomOrder()->first();
+    if (!$kategori) {
+        KategoriLembaga::factory()->create();
+        $kategori = KategoriLembaga::inRandomOrder()->first();
+    }
+    return $kategori;
+}
+
+test('it can show create lembaga page (local mode)', function () {
+    $penduduk = getLembagaPenduduk();
+    $kategori = getLembagaKategori();
+
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '0']
+    );
+
+    $response = get(route('data.lembaga.create'));
+
+    $response->assertStatus(200);
+    $response->assertSee('Tambah Lembaga');
+    $response->assertSee('penduduk_id');
+});
+
+test('it can show create lembaga page (gabungan mode)', function () {
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '1']
+    );
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'api_server_database_gabungan'],
+        ['value' => 'http://localhost:8000']
+    );
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'api_key_database_gabungan'],
+        ['value' => 'test-key']
+    );
+
+    $response = get(route('data.lembaga.create'));
+
+    $response->assertStatus(200);
+    $response->assertSee('Tambah Lembaga');
+    $response->assertSee('penduduk_id_gabungan');
+});
+
+test('it can show edit lembaga page (gabungan mode)', function () {
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '1']
+    );
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'api_server_database_gabungan'],
+        ['value' => 'http://localhost:8000']
+    );
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'api_key_database_gabungan'],
+        ['value' => 'test-key']
+    );
+
+    $penduduk = getLembagaPenduduk();
+    $kategori = getLembagaKategori();
+    $lembaga = Lembaga::factory()->create([
+        'lembaga_kategori_id' => $kategori->id,
+        'penduduk_id' => $penduduk->id,
+    ]);
+
+    $response = get(route('data.lembaga.edit', $lembaga->id));
+
+    $response->assertStatus(200);
+    $response->assertSee('Ubah Lembaga');
+    $response->assertSee('penduduk_id_gabungan');
+});
+
+test('it can create lembaga in gabungan mode with integer penduduk_id', function () {
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '1']
+    );
+
+    $penduduk = getLembagaPenduduk();
+    $kategori = getLembagaKategori();
+
+    $response = post(route('data.lembaga.store'), [
+        'nama' => 'Lembaga Test Gabungan',
+        'kode' => 'LTG-' . uniqid(),
+        'lembaga_kategori_id' => $kategori->id,
+        'penduduk_id_gabungan' => $penduduk->id,
+    ]);
+
+    $response->assertRedirect(route('data.lembaga.index'));
+    $this->assertDatabaseHas('das_lembaga', [
+        'nama' => 'Lembaga Test Gabungan',
+        'lembaga_kategori_id' => $kategori->id,
+        'penduduk_id_gabungan' => $penduduk->id,
+    ]);
+});
+
+test('it can update lembaga in gabungan mode with integer penduduk_id', function () {
+    SettingAplikasi::updateOrCreate(
+        ['key' => 'sinkronisasi_database_gabungan'],
+        ['value' => '1']
+    );
+
+    $penduduk = getLembagaPenduduk();
+    $kategori = getLembagaKategori();
+    $lembaga = Lembaga::factory()->create([
+        'lembaga_kategori_id' => $kategori->id,
+        'penduduk_id_gabungan' => $penduduk->id,
+    ]);
+
+    $newPenduduk = getLembagaPenduduk();
+
+    $response = put(route('data.lembaga.update', $lembaga->id), [
+        'nama' => 'Lembaga Updated Gabungan',
+        'kode' => $lembaga->kode,
+        'lembaga_kategori_id' => $kategori->id,
+        'penduduk_id_gabungan' => $newPenduduk->id,
+    ]);
+
+    $response->assertRedirect(route('data.lembaga.index'));
+    $this->assertDatabaseHas('das_lembaga', [
+        'id' => $lembaga->id,
+        'nama' => 'Lembaga Updated Gabungan',
+        'penduduk_id_gabungan' => $newPenduduk->id,
+    ]);
+});


### PR DESCRIPTION
## Description

Memperbaiki alur tambah dan ubah ketua lembaga beserta anggota lembaga ketika `sinkronisasi_database_gabungan` aktif (API Satu Data). Sebelumnya saat mode gabungan, data penduduk yang dipilih dari API disimpan ke kolom `penduduk_id` yang terhubung foreign key ke `das_penduduk` lokal sehingga gagal (integrity constraint violation). Sekarang dibuat kolom khusus `penduduk_id_gabungan` untuk menyimpan id penduduk dari database gabungan, plus form dan tampilan datatable yang membaca data penduduk langsung dari API.

### Changes made:

1. **Database Migration**: Menambahkan kolom `penduduk_id_gabungan` di `das_lembaga` dan `das_lembaga_anggota`, serta membuat `das_lembaga_anggota.penduduk_id` menjadi nullable dan melepas foreign key-nya.
2. **Model**: Menambahkan relasi `pendudukGabungan()` pada `Lembaga` dan `LembagaAnggota`.
3. **Services**: Menambahkan method `pendudukGabunganByIds()` pada `PendudukService` untuk mengambil beberapa data penduduk sekaligus dari API database gabungan.
4. **Controller Lembaga**: `getData()` mengambil nama ketua via `PendudukService` pada mode gabungan; `store`/`update` memetakan `penduduk_id` ke `null` dan menyimpan `penduduk_id_gabungan`; `create`/`edit` menggunakan view gabungan.
5. **Controller LembagaAnggota**: `getData()` membaca NIK/nama/tempat tanggal lahir/umur/sex/alamat dari API pada mode gabungan; `create`/`edit`/`store`/`update` mendukung database gabungan dan menggunakan view gabungan.
6. **Form Request**: `StoreLembagaRequest`, `UpdateLembagaRequest`, `StoreLembagaAnggotaRequest`, `UpdateLembagaAnggotaRequest` menyesuaikan aturan validasi untuk mode gabungan (`penduduk_id_gabungan` required, `penduduk_id` nullable).
7. **Views**: Menambahkan komponen reusable `<x-penduduk-gabungan-select>` (Select2 AJAX ke API Satu Data) dan template `data/lembaga/gabungan/*` serta `data/lembaga_anggota/gabungan/*`.
8. **Perbaikan dropdown aksi**: Menghapus `scrollX: true` pada `lembaga_anggota/index.blade.php` agar dropdown tombol aksi tidak terpotong oleh scrollbar vertikal DataTables.
9. **Tests**: Menambahkan test Fitur `LembagaControllerTest` untuk mode gabungan (tampil halaman create/edit, create/update dengan `penduduk_id_gabungan`).

### Reason for change:

- **Masalah utama**: Saat mode gabungan, id penduduk hasil pencarian dari API Satu Data disimpan ke `penduduk_id` yang ber-foreign key ke `das_penduduk` lokal. Id tersebut tidak ada di tabel lokal sehingga insert gagal (`SQLSTATE 23000`, FK constraint `das_lembaga_anggota_penduduk_id_foreign`).
- **Solusi**: Memisahkan penyimpanan id penduduk gabungan ke kolom baru `penduduk_id_gabungan` tanpa relasi FK, sehingga data dari API dapat disimpan tanpa bergantung pada data lokal.
- **Konsistensi**: Tampilan (datatable, rincian lembaga, form edit) membaca nama dan atribut penduduk secara langsung dari API pada mode gabungan, sama seperti modul data lain.

### Impact of change:

✅ **Lembaga & anggota dapat ditambah/diubah** pada mode database gabungan tanpa error FK
✅ **Datatable lembaga** menampilkan nama ketua dari API Satu Data
✅ **Datatable anggota lembaga** menampilkan NIK, nama, TTL, umur, jenis kelamin, dan alamat dari API
✅ **Komponen Select2 reusable** `<x-penduduk-gabungan-select>` memudahkan pemakaian ulang
✅ **Dropdown aksi** di halaman anggota lembaga tidak terpotong lagi

## Related Issue

- Solution for fix related to issue #[1735](https://github.com/OpenSID/OpenDK/issues/1735)

## Steps to Reproduce

### Before fix (problem):
1. Aktifkan `sinkronisasi_database_gabungan` pada pengaturan database.
2. Buka menu Tambah Lembaga, pilih ketua dari dropdown Select2 AJAX.
3. Simpan lembaga.
4. ❌ Muncul error `SQLSTATE[23000]: Integrity constraint violation ... CONSTRAINT das_lembaga_anggota_penduduk_id_foreign`.

### After fix (solution):
1. Aktifkan `sinkronisasi_database_gabungan`.
2. Buka menu Tambah Lembaga, pilih ketua dari dropdown Select2 AJAX (mengambil data dari API Satu Data).
3. Simpan lembaga.
4. ✅ Lembaga berhasil disimpan, ketua tersimpan pada kolom `penduduk_id_gabungan`.
5. ✅ Daftar lembaga dan anggota menampilkan data penduduk dari API.

### Testing on related features:
- Tambah Lembaga (mode gabungan) ✅
- Ubah Lembaga (mode gabungan) ✅
- Tambah/Ubah Anggota Lembaga (mode gabungan) ✅
- Daftar Anggota Lembaga — dropdown aksi ✅
- Lembaga & anggota mode non-gabungan (lokal) ✅

## Checklist
- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] I have created [unit test/integration test] to verify the fix
- [x] Manual testing has been done in development environment
- [ ] No console errors or warnings
- [ ] Code has been reviewed by [at least 1 person]

## Technical Details

### Technical Explanation

Saat mode gabungan aktif (`SettingAplikasi::where('key', 'sinkronisasi_database_gabungan')->value('value') === '1'`), controller memetakan data sebagai berikut:

```php
if ($this->isDatabaseGabungan()) {
    $data['penduduk_id'] = null;
    $data['penduduk_id_gabungan'] = $data['penduduk_id_gabungan'] ?? null;
}
```

`das_lembaga_anggota.penduduk_id` dibuat nullable dan foreign key-nya dilepas agar baris dengan data gabungan (tidak ada di `das_penduduk` lokal) dapat tersimpan. Data penduduk gabungan dibaca massal lewat `PendudukService::pendudukGabunganByIds()`:

```php
$data = $this->apiRequest('/api/v1/opendk/sync-penduduk-opendk', [
    'filter[kode_kecamatan]' => str_replace('.', '', config('profil.kecamatan_id')),
    'filter[id_penduduk]' => $ids,
    'page[size]' => count($ids),
]);
```

Pada form, dropdown ketua/anggota memakai komponen `<x-penduduk-gabungan-select>` yang memanggil endpoint `sync-penduduk-opendk` dengan header `Authorization: Bearer {api_key_database_gabungan}`.

### Configuration changes
Tidak ada. Perilaku ditentukan oleh setting `sinkronisasi_database_gabungan` yang sudah ada.

### Dependencies added
No new dependencies

## Testing

### Manual Testing
- [x] Tambah lembaga (mode gabungan) — ketua tersimpan di `penduduk_id_gabungan`
- [x] Ubah lembaga (mode gabungan) — ketua dapat diganti dari API
- [x] Tambah/ubah anggota lembaga (mode gabungan)
- [x] Datatable lembaga menampilkan nama ketua dari API
- [x] Datatable anggota lembaga menampilkan data penduduk dari API
- [x] Dropdown aksi pada daftar anggota lembaga tampil normal
- [x] Regression Testing — create/update/delete lembaga dan anggota mode lokal

### Automated Testing
- [x] Feature Test — `LembagaControllerTest` (5 test: tampil create/edit lokal & gabungan, create/update gabungan) — semua pas
- [x] Feature Test — `LembagaAnggotaControllerTest` (3 test: create/update/delete) — semua pas

## Screenshots / Video

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/677c7d50-88af-47bd-8cf8-79eea0216920" />


### Before:
Error `Integrity constraint violation` saat menyimpan ketua lembaga pada mode database gabungan.

### After:
Form tambah ketua lembaga menggunakan dropdown API Satu Data dan berhasil disimpan.

## Breaking Changes

Perlu penyesuaian struktur database melalui migration (`php artisan migrate`). Tidak ada perubahan breaking pada API/kontrak data. Data lama pada `penduduk_id` tetap berfungsi.

## Migration Guide

```bash
php artisan migrate --force
```

## References
- [Issue #1735](https://github.com/OpenSID/OpenDK/issues/1735)

---

**Additional notes:** Migration `2026_09_08_055444_add_penduduk_id_gabungan_to_lembaga_tables.php` perlu dijalankan; pastikan di lingkungan staging/production di-migrate sebelum rilis.